### PR TITLE
Fix build by disabling CGO

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20 as builder
+FROM golang:1.21 as builder
 
 COPY . .
 RUN make build

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ OTELCOL_BUILDER ?= ${OTELCOL_BUILDER_DIR}/ocb
 
 build: ocb
 	mkdir -p _build
-	${OTELCOL_BUILDER} --skip-compilation=false --go ${GO} --config manifest.yaml 2>&1 | tee _build/build.log
+	CGO_ENABLED=0 ${OTELCOL_BUILDER} --skip-compilation=false --go ${GO} --config manifest.yaml 2>&1 | tee _build/build.log
 
 generate-sources: ocb
 	@mkdir -p _build


### PR DESCRIPTION
Fixes
```
docker run --rm -it  -v /home/ploffay/tmp:/tmp ghcr.io/os-observability/redhat-opentelemetry-collector/redhat-opentelemetry-collector:v0.92.0  --config /tmp/config.yaml                                                                                                                         125 ↵ ploffay@fedora
Unable to find image 'ghcr.io/os-observability/redhat-opentelemetry-collector/redhat-opentelemetry-collector:v0.92.0' locally
v0.92.0: Pulling from os-observability/redhat-opentelemetry-collector/redhat-opentelemetry-collector
c2650fe947f6: Pull complete 
e6d1b7baceab: Pull complete 
d3bd4565217a: Pull complete 
Digest: sha256:59b39e6cd4f00bc41547ac81f72970c8839ace1c2b2ac22b39940beac003d1d1
Status: Downloaded newer image for ghcr.io/os-observability/redhat-opentelemetry-collector/redhat-opentelemetry-collector:v0.92.0
/otelcol: /lib64/libc.so.6: version `GLIBC_2.32' not found (required by /otelcol)
/otelcol: /lib64/libc.so.6: version `GLIBC_2.34' not found (required by /otelcol)
```