### PR TITLE
Install journalctl in collector image required by journald receiver

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,10 @@ RUN chmod 755 /opt/app-root/src/_build/otelcol
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal
 
+# Install the systemd package which provides journalctl required by journald receiver.
+# https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/journaldreceiver
+RUN microdnf -y install systemd
+
 ARG USER_UID=10001
 USER ${USER_UID}
 


### PR DESCRIPTION
The PR installs systemd package inside the collector container image which provides journalctl required by the journald receiver. Refer https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/journaldreceiver#journald-receiver 

Tested the change with the following steps.

```
 % docker build -t quay.io/rhn_support_ikanse/otel-collector:latest -f Dockerfile .
[+] Building 431.5s (14/14) FINISHED                                                                       docker:desktop-linux
 => [internal] load .dockerignore                                                                                          0.0s
 => => transferring context: 2B                                                                                            0.0s
 => [internal] load build definition from Dockerfile                                                                       0.0s
 => => transferring dockerfile: 916B                                                                                       0.0s
 => [internal] load metadata for registry.access.redhat.com/ubi8/ubi-minimal:latest                                        1.3s
 => [stage-1 1/4] FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:288239021a429a311233d73a7d91b0a1dd889ab7bbc247d  0.0s
 => [internal] load build context                                                                                          0.0s
 => => transferring context: 8.71kB                                                                                        0.0s
 => CACHED [builder 2/6] RUN microdnf -y install which go-toolset make                                                     0.0s
 => CACHED [builder 3/6] WORKDIR /opt/app-root/src                                                                         0.0s
 => [builder 4/6] COPY . .                                                                                                 0.0s
 => [builder 5/6] RUN make build                                                                                         429.6s
 => [builder 6/6] RUN chmod 755 /opt/app-root/src/_build/otelcol                                                           0.4s 
 => CACHED [stage-1 2/4] RUN microdnf -y install systemd                                                                   0.0s 
 => CACHED [stage-1 3/4] COPY --from=builder /opt/app-root/src/_build/otelcol /                                            0.0s 
 => CACHED [stage-1 4/4] COPY configs/otelcol.yaml /etc/otelcol/config.yaml                                                0.0s 
 => exporting to image                                                                                                     0.0s 
 => => exporting layers                                                                                                    0.0s 
 => => writing image sha256:7f0a93f8c24d7f50e4d02ac547190a530b7a80379350e413f1365b2ba495125f                               0.0s
 => => naming to quay.io/rhn_support_ikanse/otel-collector:latest                                                          0.0s

View build details: docker-desktop://dashboard/build/desktop-linux/desktop-linux/i7cbvh1pwc74xamws692uetfj

What's Next?
  1. Sign in to your Docker account → docker login
  2. View a summary of image vulnerabilities and recommendations → docker scout quickview
 
 % docker run -it --entrypoint=bash quay.io/rhn_support_ikanse/otel-collector:latest
bash-4.4$ 
bash-4.4$ journalctl --version
systemd 239 (239-78.el8)
+PAM +AUDIT +SELINUX +IMA -APPARMOR +SMACK +SYSVINIT +UTMP +LIBCRYPTSETUP +GCRYPT +GNUTLS +ACL +XZ +LZ4 +SECCOMP +BLKID +ELFUTILS +KMOD +IDN2 -IDN +PCRE2 default-hierarchy=legacy
bash-4.4$ 
```
