### PR TITLE
Add user to systemd-journal group in collector container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,11 +12,12 @@ RUN chmod 755 /opt/app-root/src/_build/otelcol
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal
 
-# Install the systemd package which provides journalctl required by journald receiver.
+# Install the systemd package which provides journalctl required by journald receiver and add user to systemd-journal group.
 # https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/journaldreceiver
 RUN microdnf -y install systemd
-
 ARG USER_UID=10001
+RUN useradd -u ${USER_UID} otelcol && usermod -a -G systemd-journal otelcol
+
 USER ${USER_UID}
 
 COPY --from=builder /opt/app-root/src/_build/otelcol /


### PR DESCRIPTION
Adds the user in the collector container image to systemd-journal group. Without the group, we get permission denied errors  reading the journal mounted from the OpenShift nodes. 

```
% oc logs otel-logs-sidecar-collector-7k5kg
2024-01-25T04:48:11.316Z	info	service@v0.92.0/telemetry.go:86	Setting up own telemetry...
2024-01-25T04:48:11.316Z	info	service@v0.92.0/telemetry.go:159	Serving metrics	{"address": ":8888", "level": "Basic"}
2024-01-25T04:48:11.316Z	info	exporter@v0.92.0/exporter.go:275	Deprecated component. Will be removed in future releases.	{"kind": "exporter", "data_type": "logs", "name": "logging"}
2024-01-25T04:48:11.329Z	info	service@v0.92.0/service.go:151	Starting otelcol...	{"Version": "0.92.0", "NumCPU": 4}
2024-01-25T04:48:11.329Z	info	extensions/extensions.go:34	Starting extensions...
2024-01-25T04:48:11.329Z	info	adapter/receiver.go:45	Starting stanza receiver	{"kind": "receiver", "name": "journald", "data_type": "logs"}
2024-01-25T04:48:11.332Z	info	service@v0.92.0/service.go:191	Starting shutdown...
2024-01-25T04:48:11.332Z	info	adapter/receiver.go:140	Stopping stanza receiver	{"kind": "receiver", "name": "journald", "data_type": "logs"}
2024-01-25T04:48:11.333Z	info	extensions/extensions.go:59	Stopping extensions...
2024-01-25T04:48:11.333Z	info	service@v0.92.0/service.go:205	Shutdown complete.
Error: cannot start pipelines: start stanza: journalctl command failed (exit status 1): Failed to open files: Permission denied

```

With the change, we are able to use the journald receiver to collect the journal logs. 
```
ikanse@ikanse-mac ~ % oc logs otel-joural-logs-collector-qz22k | head -n 30
2024-01-25T07:13:35.208Z	info	service@v0.92.0/telemetry.go:86	Setting up own telemetry...
2024-01-25T07:13:35.210Z	info	service@v0.92.0/telemetry.go:159	Serving metrics	{"address": ":8888", "level": "Basic"}
2024-01-25T07:13:35.210Z	info	exporter@v0.92.0/exporter.go:275	Deprecated component. Will be removed in future releases.	{"kind": "exporter", "data_type": "logs", "name": "logging"}
2024-01-25T07:13:35.222Z	info	service@v0.92.0/service.go:151	Starting otelcol...	{"Version": "0.92.0", "NumCPU": 4}
2024-01-25T07:13:35.222Z	info	extensions/extensions.go:34	Starting extensions...
2024-01-25T07:13:35.222Z	info	adapter/receiver.go:45	Starting stanza receiver	{"kind": "receiver", "name": "journald", "data_type": "logs"}
2024-01-25T07:13:36.224Z	info	service@v0.92.0/service.go:177	Everything is ready. Begin running and processing data.
2024-01-25T07:13:36.224Z	info	LogsExporter	{"kind": "exporter", "data_type": "logs", "name": "logging", "resource logs": 1, "log records": 10}
2024-01-25T07:13:36.224Z	info	ResourceLog #0
Resource SchemaURL: 
ScopeLogs #0
ScopeLogs SchemaURL: 
InstrumentationScope  
LogRecord #0
ObservedTimestamp: 2024-01-25 07:13:35.226559977 +0000 UTC
Timestamp: 2024-01-25 07:13:35.074593 +0000 UTC
SeverityText: 
SeverityNumber: Unspecified(0)
Body: Map({"MESSAGE":"time=\"2024-01-25 07:13:35.074551733Z\" level=info msg=\"Pulled image: quay.io/rhn_support_ikanse/otel-collector@sha256:5b6344e6d6daf5014fff20ff6907bd2fe4c21ed0c1949946a89b5c8a8d77d672\" id=642a35ac-3063-463e-a73c-fd03b7d96faa name=/runtime.v1.ImageService/PullImage","PRIORITY":"6","SYSLOG_FACILITY":"3","SYSLOG_IDENTIFIER":"crio","_BOOT_ID":"e9b17b8187094fe7b26848f9a2aa16a7","_CAP_EFFECTIVE":"1ffffffffff","_CMDLINE":"/usr/bin/crio","_COMM":"crio","_EXE":"/usr/bin/crio","_GID":"0","_HOSTNAME":"ip-10-0-44-68","_MACHINE_ID":"ec282e1f9c6dfdfaf58e89cf9877ebec","_PID":"2090","_RUNTIME_SCOPE":"system","_SELINUX_CONTEXT":"system_u:system_r:container_runtime_t:s0","_STREAM_ID":"f65cac28756446779f3e3c83cd3685a2","_SYSTEMD_CGROUP":"/system.slice/crio.service","_SYSTEMD_INVOCATION_ID":"d0f655fa894e46ee9fd440c737b78cb2","_SYSTEMD_SLICE":"system.slice","_SYSTEMD_UNIT":"crio.service","_TRANSPORT":"stdout","_UID":"0","__CURSOR":"s=62decd914b864960993f8bbb7f815ec8;i=34d1;b=e9b17b8187094fe7b26848f9a2aa16a7;m=3104299fb;t=60fbfeaf0a921;x=17ab76e6bd438aa5","__MONOTONIC_TIMESTAMP":"13157702139"})
Trace ID: 
Span ID: 
Flags: 0
LogRecord #1
ObservedTimestamp: 2024-01-25 07:13:35.226596482 +0000 UTC
Timestamp: 2024-01-25 07:13:35.07576 +0000 UTC
SeverityText: 
SeverityNumber: Unspecified(0)
Body: Map({"MESSAGE":"time=\"2024-01-25 07:13:35.075521591Z\" level=info msg=\"Checking image status: quay.io/rhn_support_ikanse/otel-collector:latest\" id=780af80d-8a9b-429b-877d-3e9b3ecd6a2a name=/runtime.v1.ImageService/ImageStatus","PRIORITY":"6","SYSLOG_FACILITY":"3","SYSLOG_IDENTIFIER":"crio","_BOOT_ID":"e9b17b8187094fe7b26848f9a2aa16a7","_CAP_EFFECTIVE":"1ffffffffff","_CMDLINE":"/usr/bin/crio","_COMM":"crio","_EXE":"/usr/bin/crio","_GID":"0","_HOSTNAME":"ip-10-0-44-68","_MACHINE_ID":"ec282e1f9c6dfdfaf58e89cf9877ebec","_PID":"2090","_RUNTIME_SCOPE":"system","_SELINUX_CONTEXT":"system_u:system_r:container_runtime_t:s0","_STREAM_ID":"f65cac28756446779f3e3c83cd3685a2","_SYSTEMD_CGROUP":"/system.slice/crio.service","_SYSTEMD_INVOCATION_ID":"d0f655fa894e46ee9fd440c737b78cb2","_SYSTEMD_SLICE":"system.slice","_SYSTEMD_UNIT":"crio.service","_TRANSPORT":"stdout","_UID":"0","__CURSOR":"s=62decd914b864960993f8bbb7f815ec8;i=34d2;b=e9b17b8187094fe7b26848f9a2aa16a7;m=310429e89;t=60fbfeaf0adb0;x=f4850869af22d200","__MONOTONIC_TIMESTAMP":"13157703305"})
Trace ID: 
Span ID: 
```