### PR TITLE
Use the proper golang compiler

### DIFF
--- a/collector.spec.in
+++ b/collector.spec.in
@@ -20,7 +20,7 @@ License:        Apache-2.0
 Source0:        %{name}-%{version}.tar.gz
 Source1:        %{name}-deps-%{version}.tar.gz
 
-BuildRequires: go-toolset-1.20
+BuildRequires: %{?go_compiler:compiler(go-compiler)}%{!?go_compiler:golang}
 BuildRequires: git
 
 %description


### PR DESCRIPTION
Choose the right golang package depending on where the RPM is being built.