### PR TITLE
Fallback to ocb 0.93.0 to stay with go 1.20

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 GO=$(shell which go)
 OTELCOL_VERSION ?= 0.95.0
+# TODO: Align the ocb version with the collector version as soon as the ubi go 1.21 is supported.
+OCB_VERSION ?= 0.93.0
 OTELCOL_BUILDER_DIR ?= ${PWD}/bin
 OTELCOL_BUILDER ?= ${OTELCOL_BUILDER_DIR}/ocb
 PROJECT ?= redhat-opentelemetry-collector
@@ -24,7 +26,7 @@ ifeq (, $(shell which ocb >/dev/null 2>/dev/null))
 	[ "$${machine}" != x86_64 ] || machine=amd64 ;\
 	echo "Installing ocb ($${os}/$${machine}) at $(OTELCOL_BUILDER_DIR)";\
 	mkdir -p $(OTELCOL_BUILDER_DIR) ;\
-	curl -sLo $(OTELCOL_BUILDER) "https://github.com/open-telemetry/opentelemetry-collector/releases/download/cmd%2Fbuilder%2Fv$(OTELCOL_VERSION)/ocb_$(OTELCOL_VERSION)_$${os}_$${machine}" ;\
+	curl -sLo $(OTELCOL_BUILDER) "https://github.com/open-telemetry/opentelemetry-collector/releases/download/cmd%2Fbuilder%2Fv$(OCB_VERSION)/ocb_$(OCB_VERSION)_$${os}_$${machine}" ;\
 	chmod +x $(OTELCOL_BUILDER) ;\
 	}
 else

--- a/_build/build.log
+++ b/_build/build.log
@@ -1,13 +1,13 @@
 Flag --go has been deprecated, use config distribution::go
-2024-02-28T10:56:10.378Z	INFO	internal/command.go:123	OpenTelemetry Collector Builder	{"version": "0.95.0", "date": "2024-02-20T17:40:58Z"}
-2024-02-28T10:56:10.379Z	INFO	internal/command.go:159	Using config file	{"path": "manifest.yaml"}
-2024-02-28T10:56:10.463Z	INFO	builder/config.go:109	Using go	{"go-executable": "/usr/bin/go"}
-2024-02-28T10:56:10.463Z	INFO	builder/main.go:67	You're building a distribution with non-aligned version of the builder. Compilation may fail due to API changes. Please upgrade your builder or API	{"builder-version": "0.94.0"}
-2024-02-28T10:56:10.464Z	INFO	builder/main.go:91	Sources created	{"path": "./_build"}
-2024-02-28T10:56:10.464Z	INFO	builder/main.go:25	Running go subcommand.	{"arguments": ["get", "cloud.google.com/go"]}
-2024-02-28T10:56:10.784Z	INFO	builder/main.go:25	Running go subcommand.	{"arguments": ["mod", "tidy", "-compat=1.21"]}
-2024-02-28T10:56:30.540Z	INFO	builder/main.go:142	Getting go modules
-2024-02-28T10:56:30.540Z	INFO	builder/main.go:25	Running go subcommand.	{"arguments": ["mod", "download"]}
-2024-02-28T10:56:35.248Z	INFO	builder/main.go:102	Compiling
-2024-02-28T10:56:35.248Z	INFO	builder/main.go:25	Running go subcommand.	{"arguments": ["build", "-trimpath", "-o", "otelcol", "-ldflags=-s -w"]}
-2024-02-28T10:59:16.776Z	INFO	builder/main.go:121	Compiled	{"binary": "./_build/otelcol"}
+2024-02-28T14:14:27.135+0100	INFO	internal/command.go:123	OpenTelemetry Collector Builder	{"version": "0.93.0", "date": "2024-01-24T11:10:24Z"}
+2024-02-28T14:14:27.136+0100	INFO	internal/command.go:159	Using config file	{"path": "manifest.yaml"}
+2024-02-28T14:14:27.140+0100	INFO	builder/config.go:109	Using go	{"go-executable": "/usr/local/go/bin/go"}
+2024-02-28T14:14:27.140+0100	INFO	builder/main.go:67	You're building a distribution with non-aligned version of the builder. Compilation may fail due to API changes. Please upgrade your builder or API	{"builder-version": "0.93.0"}
+2024-02-28T14:14:27.142+0100	INFO	builder/main.go:91	Sources created	{"path": "./_build"}
+2024-02-28T14:14:27.142+0100	INFO	builder/main.go:25	Running go subcommand.	{"arguments": ["get", "cloud.google.com/go"]}
+2024-02-28T14:14:27.456+0100	INFO	builder/main.go:25	Running go subcommand.	{"arguments": ["mod", "tidy", "-compat=1.20"]}
+2024-02-28T14:14:46.180+0100	INFO	builder/main.go:142	Getting go modules
+2024-02-28T14:14:46.180+0100	INFO	builder/main.go:25	Running go subcommand.	{"arguments": ["mod", "download"]}
+2024-02-28T14:14:51.045+0100	INFO	builder/main.go:102	Compiling
+2024-02-28T14:14:51.045+0100	INFO	builder/main.go:25	Running go subcommand.	{"arguments": ["build", "-trimpath", "-o", "otelcol", "-ldflags=-s -w"]}
+2024-02-28T14:14:55.521+0100	INFO	builder/main.go:121	Compiled	{"binary": "./_build/otelcol"}


### PR DESCRIPTION
We should align the version with the collector version once the go base image uses go 1.21.

Fixes #48 