### PR TITLE
Add memory limiter extension

### DIFF
--- a/_build/build.log
+++ b/_build/build.log
@@ -1,13 +1,13 @@
 Flag --go has been deprecated, use config distribution::go
-2024-03-08T11:15:20.879+0100	INFO	internal/command.go:123	OpenTelemetry Collector Builder	{"version": "0.93.0", "date": "2024-01-24T11:10:24Z"}
-2024-03-08T11:15:20.880+0100	INFO	internal/command.go:159	Using config file	{"path": "manifest.yaml"}
-2024-03-08T11:15:20.886+0100	INFO	builder/config.go:109	Using go	{"go-executable": "/home/ploffay/bin/go/bin/go"}
-2024-03-08T11:15:20.886+0100	INFO	builder/main.go:67	You're building a distribution with non-aligned version of the builder. Compilation may fail due to API changes. Please upgrade your builder or API	{"builder-version": "0.93.0"}
-2024-03-08T11:15:20.887+0100	INFO	builder/main.go:91	Sources created	{"path": "./_build"}
-2024-03-08T11:15:20.887+0100	INFO	builder/main.go:25	Running go subcommand.	{"arguments": ["get", "cloud.google.com/go"]}
-2024-03-08T11:15:21.571+0100	INFO	builder/main.go:25	Running go subcommand.	{"arguments": ["mod", "tidy", "-compat=1.20"]}
-2024-03-08T11:15:21.786+0100	INFO	builder/main.go:142	Getting go modules
-2024-03-08T11:15:21.786+0100	INFO	builder/main.go:25	Running go subcommand.	{"arguments": ["mod", "download"]}
-2024-03-08T11:15:21.861+0100	INFO	builder/main.go:102	Compiling
-2024-03-08T11:15:21.861+0100	INFO	builder/main.go:25	Running go subcommand.	{"arguments": ["build", "-trimpath", "-o", "otelcol", "-ldflags=-s -w"]}
-2024-03-08T11:15:22.472+0100	INFO	builder/main.go:121	Compiled	{"binary": "./_build/otelcol"}
+2024-03-12T08:06:53.017-0600	INFO	internal/command.go:123	OpenTelemetry Collector Builder	{"version": "0.93.0", "date": "2024-01-24T11:10:24Z"}
+2024-03-12T08:06:53.017-0600	INFO	internal/command.go:159	Using config file	{"path": "manifest.yaml"}
+2024-03-12T08:06:53.025-0600	INFO	builder/config.go:109	Using go	{"go-executable": "/home/rvargasp/go/bin/go"}
+2024-03-12T08:06:53.025-0600	INFO	builder/main.go:67	You're building a distribution with non-aligned version of the builder. Compilation may fail due to API changes. Please upgrade your builder or API	{"builder-version": "0.93.0"}
+2024-03-12T08:06:53.027-0600	INFO	builder/main.go:91	Sources created	{"path": "./_build"}
+2024-03-12T08:06:53.027-0600	INFO	builder/main.go:25	Running go subcommand.	{"arguments": ["get", "cloud.google.com/go"]}
+2024-03-12T08:06:54.187-0600	INFO	builder/main.go:25	Running go subcommand.	{"arguments": ["mod", "tidy", "-compat=1.20"]}
+2024-03-12T08:06:54.828-0600	INFO	builder/main.go:142	Getting go modules
+2024-03-12T08:06:54.828-0600	INFO	builder/main.go:25	Running go subcommand.	{"arguments": ["mod", "download"]}
+2024-03-12T08:06:54.887-0600	INFO	builder/main.go:102	Compiling
+2024-03-12T08:06:54.887-0600	INFO	builder/main.go:25	Running go subcommand.	{"arguments": ["build", "-trimpath", "-o", "otelcol", "-ldflags=-s -w"]}
+2024-03-12T08:06:57.923-0600	INFO	builder/main.go:121	Compiled	{"binary": "./_build/otelcol"}

--- a/_build/components.go
+++ b/_build/components.go
@@ -19,6 +19,7 @@ import (
 	awscloudwatchlogsexporter "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awscloudwatchlogsexporter"
 	zpagesextension "go.opentelemetry.io/collector/extension/zpagesextension"
 	ballastextension "go.opentelemetry.io/collector/extension/ballastextension"
+	memorylimiterextension "go.opentelemetry.io/collector/extension/memorylimiterextension"
 	jaegerremotesampling "github.com/open-telemetry/opentelemetry-collector-contrib/extension/jaegerremotesampling"
 	healthcheckextension "github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension"
 	pprofextension "github.com/open-telemetry/opentelemetry-collector-contrib/extension/pprofextension"
@@ -53,6 +54,7 @@ func components() (otelcol.Factories, error) {
 	factories.Extensions, err = extension.MakeFactoryMap(
 		zpagesextension.NewFactory(),
 		ballastextension.NewFactory(),
+		memorylimiterextension.NewFactory(),
 		jaegerremotesampling.NewFactory(),
 		healthcheckextension.NewFactory(),
 		pprofextension.NewFactory(),

--- a/_build/go.mod
+++ b/_build/go.mod
@@ -41,6 +41,7 @@ require (
 	go.opentelemetry.io/collector/exporter/otlphttpexporter v0.95.0
 	go.opentelemetry.io/collector/extension v0.95.0
 	go.opentelemetry.io/collector/extension/ballastextension v0.95.0
+	go.opentelemetry.io/collector/extension/memorylimiterextension v0.95.0
 	go.opentelemetry.io/collector/extension/zpagesextension v0.95.0
 	go.opentelemetry.io/collector/otelcol v0.95.0
 	go.opentelemetry.io/collector/processor v0.95.0

--- a/_build/go.sum
+++ b/_build/go.sum
@@ -881,6 +881,8 @@ go.opentelemetry.io/collector/extension/auth v0.95.0 h1:Qu2/I6YXW1yhh+M5PZ6b5izP
 go.opentelemetry.io/collector/extension/auth v0.95.0/go.mod h1:FSODnSbmqfRT9dQdJgogby7j4bcV8TmrhddTvcAjcjU=
 go.opentelemetry.io/collector/extension/ballastextension v0.95.0 h1:ikdfIQiTktrVws4EhDH7I/BNIgfBJiIk+fdkmyh2VCY=
 go.opentelemetry.io/collector/extension/ballastextension v0.95.0/go.mod h1:J6ErxwsYS+7DD7wKNFaPe2Yh6iFzmWLJs4YEpmI6VgU=
+go.opentelemetry.io/collector/extension/memorylimiterextension v0.95.0 h1:E++Lrq8EBbNM9HKQurp/JwYZSCL0d420GPDx6xlNAlU=
+go.opentelemetry.io/collector/extension/memorylimiterextension v0.95.0/go.mod h1:a6qCi3k0BGGbeRskOFenBE2T7avv7+MXmGa7vXBmAWE=
 go.opentelemetry.io/collector/extension/zpagesextension v0.95.0 h1:O9TNgmPDFZOyBxbmeEqmsp9r2ZBYOAqpNXSgKAV915o=
 go.opentelemetry.io/collector/extension/zpagesextension v0.95.0/go.mod h1:CfvfIazNopdw9EK1rQXKMyRBwNJ5UzXBY4+U37PcBoE=
 go.opentelemetry.io/collector/featuregate v1.2.0 h1:nF8OGq5PsSNSLeuNwTWlOqThxbLW6v6DOCvSqQMc108=

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -28,6 +28,7 @@ exporters:
 extensions:
   - gomod: go.opentelemetry.io/collector/extension/zpagesextension v0.95.0
   - gomod: go.opentelemetry.io/collector/extension/ballastextension v0.95.0
+  - gomod: go.opentelemetry.io/collector/extension/memorylimiterextension v0.95.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/jaegerremotesampling v0.95.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension v0.95.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/pprofextension v0.95.0


### PR DESCRIPTION
I don't know if we need to remove the ballast  extension also (this PR removes it), is deprecated and cannot be used with this extension


https://github.com/open-telemetry/opentelemetry-collector/blob/main/extension/memorylimiterextension/README.md

> Warning
> 
> The memory_limiter extension cannot be used if the deprecated memory_ballast extension is enabled.
> 