### PR TITLE
set packit ownership

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -50,6 +50,8 @@ jobs:
 
   - job: copr_build
     trigger: commit
+    owner: "@os-observability"
+    project: "redhat-opentelemetry-collector-main"
     preserve_project: True
     branch: "^main$"
     targets:


### PR DESCRIPTION
Set ownership.

e.g.:
https://github.com/cockpit-project/cockpit-podman/blob/bc478e9c49badbae1c44f43a9875212bdeb9c042/packit.yaml#L54-L59

Closes https://github.com/os-observability/redhat-opentelemetry-collector/issues/70

---

cc @miyunari  @fkolwa