### PR TITLE
use frzfius as package owner

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -41,7 +41,7 @@ jobs:
     trigger: pull_request
     targets:
       - fedora-40-x86_64
-      - rhel-9-x86_64
+      - epel-9-x86_64
 
   - job: tests
     trigger: pull_request
@@ -50,16 +50,15 @@ jobs:
 
   - job: copr_build
     trigger: commit
-    owner: "@os-observability"
+    owner: "frzifus"
     project: "redhat-opentelemetry-collector-main"
     preserve_project: True
     branch: "^main$"
     targets:
       - fedora-40-x86_64
-      - fedora-40-x86_64
-      - rhel-9-x86_64
+      - epel-9-x86_64
       - fedora-40-aarch64
-      - rhel-9-aarch64
+      - epel-9-aarch64
 
   - job: tests
     trigger: commit


### PR DESCRIPTION
Use this until the @os-observability group is approved.

https://copr.fedorainfracloud.org/coprs/frzifus/redhat-opentelemetry-collector-main/