### PR TITLE
Add test cases for OTEL collector components

### DIFF
--- a/.chainsaw.yaml
+++ b/.chainsaw.yaml
@@ -1,0 +1,13 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/configuration-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Configuration
+metadata:
+  name: configuration
+spec:
+  parallel: 4
+  timeouts:
+    assert: 6m0s
+    cleanup: 5m0s
+    delete: 5m0s
+    error: 5m0s
+    apply: 10s

--- a/tests/e2e-otel/countconnector/assert-generate-telemetry-data.yaml
+++ b/tests/e2e-otel/countconnector/assert-generate-telemetry-data.yaml
@@ -1,0 +1,22 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: generate-logs
+status:
+  succeeded: 1
+
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: generate-traces
+status:
+  succeeded: 1
+
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: generate-metrics
+status:
+  succeeded: 1

--- a/tests/e2e-otel/countconnector/assert-otel-collector.yaml
+++ b/tests/e2e-otel/countconnector/assert-otel-collector.yaml
@@ -1,0 +1,63 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: count-collector
+status:
+  availableReplicas: 1
+  readyReplicas: 1
+  replicas: 1
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: opentelemetry-collector
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/name: count-collector
+    app.kubernetes.io/part-of: opentelemetry
+    operator.opentelemetry.io/collector-service-type: base
+  name: count-collector
+spec:
+  ports:
+  - appProtocol: grpc
+    name: otlp-grpc
+    port: 4317
+    protocol: TCP
+    targetPort: 4317
+  - appProtocol: http
+    name: otlp-http
+    port: 4318
+    protocol: TCP
+    targetPort: 4318
+  - name: prometheus
+    port: 8889
+    protocol: TCP
+    targetPort: 8889
+  selector:
+    app.kubernetes.io/component: opentelemetry-collector
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/part-of: opentelemetry
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: opentelemetry-collector
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/name: count-collector-monitoring
+    app.kubernetes.io/part-of: opentelemetry
+    operator.opentelemetry.io/collector-monitoring-service: Exists
+    operator.opentelemetry.io/collector-service-type: monitoring
+  name: count-collector-monitoring
+spec:
+  ports:
+  - name: monitoring
+    port: 8888
+    protocol: TCP
+    targetPort: 8888
+  selector:
+    app.kubernetes.io/component: opentelemetry-collector
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/part-of: opentelemetry

--- a/tests/e2e-otel/countconnector/chainsaw-test.yaml
+++ b/tests/e2e-otel/countconnector/chainsaw-test.yaml
@@ -1,0 +1,44 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: countconnector
+spec:
+  steps:
+  - name: Create OTEL collector instance
+    try:
+    - apply:
+        file: otel-collector.yaml
+    - assert:
+        file: assert-otel-collector.yaml
+  - name: Generate telemetry data. Traces, metrics and logs.
+    try:
+    - apply:
+        file: generate-telemetry-data.yaml
+    - assert:
+        file: assert-generate-telemetry-data.yaml
+  - name: Check the metrics from the count connector
+    try:
+    - proxy:
+        apiVersion: v1
+        kind: Service
+        namespace: ($namespace)
+        name: count-collector
+        port: prometheus
+        path: /metrics
+        outputs:
+        - name: metrics
+          value: (x_metrics_decode($stdout))
+    - assert:
+        resource:
+          # Check for log_record_count_total
+          ($metrics[?as_string(metric.__name__) == 'dev_log_count_total'].value): 
+          - 1
+          # Check for metric_count_total
+          ($metrics[?as_string(metric.__name__) == 'metric_count_total'].value):
+          - 1
+          # Check for metric_datapoint_count_total
+          ($metrics[?as_string(metric.__name__) == 'dev_metrics_datapoint_total'].value):
+          - 1
+          # Check for trace_span_count_total
+          ($metrics[?as_string(metric.__name__) == 'dev_span_count_total'].value):
+          - 10

--- a/tests/e2e-otel/countconnector/generate-telemetry-data.yaml
+++ b/tests/e2e-otel/countconnector/generate-telemetry-data.yaml
@@ -1,0 +1,58 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: generate-traces
+spec:
+  template:
+    spec:
+      containers:
+      - name: telemetrygen
+        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.112.0
+        args:
+        - traces
+        - --otlp-endpoint=count-collector:4317
+        - --otlp-insecure=true
+        - --traces=5
+        - "--otlp-attributes=telemetrygentype=\"traces\""
+      restartPolicy: Never
+  backoffLimit: 4
+
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: generate-metrics
+spec:
+  template:
+    spec:
+      containers:
+      - name: telemetrygen
+        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.112.0
+        args:
+        - metrics
+        - --otlp-endpoint=count-collector:4317
+        - --otlp-insecure=true
+        - --metrics=5
+        - "--otlp-attributes=telemetrygentype=\"metrics\""
+      restartPolicy: Never
+  backoffLimit: 4
+
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: generate-logs
+spec:
+  template:
+    spec:
+      containers:
+      - name: telemetrygen
+        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.112.0
+        args:
+        - logs
+        - --otlp-endpoint=count-collector:4317
+        - --otlp-insecure=true
+        - --logs=5
+        - "--otlp-attributes=telemetrygentype=\"logs\""
+      restartPolicy: Never
+  backoffLimit: 4

--- a/tests/e2e-otel/countconnector/otel-collector.yaml
+++ b/tests/e2e-otel/countconnector/otel-collector.yaml
@@ -1,0 +1,58 @@
+apiVersion: opentelemetry.io/v1beta1
+kind: OpenTelemetryCollector
+metadata:
+  name: count
+spec:
+  mode: deployment
+  observability:
+    metrics:
+      enableMetrics: true
+  config:
+    receivers:
+      otlp:
+        protocols:
+          grpc: {}
+          http:  {}
+    processors: {}
+    connectors:
+      count:
+        logs:
+          dev.log.count:
+            description: The number of logs from each environment.
+            attributes:
+              - key: telemetrygentype
+                default_value: unspecified_environment
+        datapoints:
+          dev.metrics.datapoint:
+            description: The number of metric datapoints from each environment.
+            attributes:
+              - key: telemetrygentype
+                default_value: unspecified_environment
+        spans:
+          dev.span.count:
+            description: The number of spans from each environment.
+            attributes:
+              - key: telemetrygentype
+                default_value: unspecified_environment
+    exporters:
+      prometheus:
+        endpoint: 0.0.0.0:8889
+        resource_to_telemetry_conversion:
+          enabled: true
+      debug:
+        verbosity: detailed
+    service:
+      pipelines:
+        traces:
+          receivers: [otlp]
+          exporters: [count,debug]
+        metrics:
+          receivers: [otlp]
+          exporters: [count,debug]
+        logs:
+          receivers: [otlp]
+          exporters: [count,debug]
+        metrics/count:
+          receivers: [count]
+          exporters: [prometheus]
+

--- a/tests/e2e-otel/filelog/00-assert.yaml
+++ b/tests/e2e-otel/filelog/00-assert.yaml
@@ -1,0 +1,68 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: otel-logs-collector
+status:
+  availableReplicas: 1
+  readyReplicas: 1
+  replicas: 1
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: otel-logs-collector
+spec:
+  ports:
+  - appProtocol: grpc
+    name: otlp-grpc
+    port: 4317
+    protocol: TCP
+    targetPort: 4317
+  - appProtocol: http
+    name: otlp-http
+    port: 4318
+    protocol: TCP
+    targetPort: 4318
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: otel-logs-collector-headless
+spec:
+  ports:
+  - appProtocol: grpc
+    name: otlp-grpc
+    port: 4317
+    protocol: TCP
+    targetPort: 4317
+  - appProtocol: http
+    name: otlp-http
+    port: 4318
+    protocol: TCP
+    targetPort: 4318
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: otel-logs-collector-monitoring
+spec:
+  ports:
+  - name: monitoring
+    port: 8888
+    protocol: TCP
+    targetPort: 8888
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: otel-logs-sidecar-collector-monitoring
+spec:
+  ports:
+  - name: monitoring
+    port: 8888
+    protocol: TCP
+    targetPort: 8888

--- a/tests/e2e-otel/filelog/00-otel-filelog.yaml
+++ b/tests/e2e-otel/filelog/00-otel-filelog.yaml
@@ -1,0 +1,57 @@
+apiVersion: opentelemetry.io/v1alpha1
+kind: OpenTelemetryCollector
+metadata:
+  name: otel-logs
+spec:
+  mode: deployment
+  config: |
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+          http:
+    processors:
+    exporters:
+      debug:
+        verbosity: detailed
+    service:
+      pipelines:
+        logs:
+          receivers: [otlp]
+          processors: []
+          exporters: [debug]
+
+---
+apiVersion: opentelemetry.io/v1alpha1
+kind: OpenTelemetryCollector
+metadata:
+  name: otel-logs-sidecar
+spec:
+  mode: sidecar
+  config: |
+    receivers:
+      filelog:
+        include: [ /log-data/*.log ]
+        operators:
+          - type: regex_parser
+            regex: '^(?P<time>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3}) - (?P<logger>\S+) - (?P<sev>\S+) - (?P<message>.*)$'
+            timestamp:
+              parse_from: attributes.time
+              layout: '%Y-%m-%d %H:%M:%S'
+            severity:
+              parse_from: attributes.sev
+    processors:
+    exporters:
+      otlp:
+        endpoint: otel-logs-collector:4317
+        tls:
+          insecure: true
+    service:
+      pipelines:
+        logs:
+          receivers: [filelog]
+          processors: []
+          exporters: [otlp]
+  volumeMounts:
+  - name: log-data
+    mountPath: /log-data

--- a/tests/e2e-otel/filelog/01-app-plaintext-logs.yaml
+++ b/tests/e2e-otel/filelog/01-app-plaintext-logs.yaml
@@ -1,0 +1,57 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: app-log-plaintext-config
+data:
+  ocp_logtest.cfg: --rate 60.0 -o /log-data/app-log-plaintext.log
+
+---
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  labels:
+    run: otel-logtest-plaintext
+    test: otel-logtest-plaintext
+  name: app-log-plaintext-rc
+spec:
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        containerType.logging.openshift.io/app-log-plaintext: app-log-plaintext
+        sidecar.opentelemetry.io/inject: "true"
+      generateName: otel-logtest-
+      labels:
+        run: otel-logtest-plaintext
+        test: otel-logtest-plaintext
+    spec:
+      containers:
+      - env: []
+        image: quay.io/openshifttest/ocp-logtest@sha256:6e2973d7d454ce412ad90e99ce584bf221866953da42858c4629873e53778606
+        imagePullPolicy: IfNotPresent
+        name: app-log-plaintext
+        resources: {}
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
+          privileged: false
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+        terminationMessagePath: /dev/termination-log
+        volumeMounts:
+        - mountPath: /log-data
+          name: log-data
+        - mountPath: /var/lib/svt
+          name: config
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      volumes:
+      - configMap:
+          name: app-log-plaintext-config
+        name: config
+      - name: log-data
+        emptyDir: {}

--- a/tests/e2e-otel/filelog/01-assert.yaml
+++ b/tests/e2e-otel/filelog/01-assert.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  labels:
+    run: otel-logtest-plaintext
+    test: otel-logtest-plaintext
+  name: app-log-plaintext-rc
+status:
+  availableReplicas: 1
+  readyReplicas: 1
+  replicas: 1
+
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    containerType.logging.openshift.io/app-log-plaintext: app-log-plaintext
+    sidecar.opentelemetry.io/inject: "true"
+  labels:
+    run: otel-logtest-plaintext
+status:
+  phase: Running

--- a/tests/e2e-otel/filelog/chainsaw-test.yaml
+++ b/tests/e2e-otel/filelog/chainsaw-test.yaml
@@ -1,0 +1,53 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: filelog
+spec:
+  steps:
+  - name: step-00
+    try:
+    - command:
+        args:
+        - -n
+        - $NAMESPACE
+        - create
+        - rolebinding
+        - default-view-$NAMESPACE
+        - --role=pod-view
+        - --serviceaccount=$NAMESPACE:ta
+        entrypoint: kubectl
+    - command:
+        args:
+        - annotate
+        - namespace
+        - ${NAMESPACE}
+        - openshift.io/sa.scc.uid-range=1000/1000
+        - --overwrite
+        entrypoint: kubectl
+    - command:
+        args:
+        - annotate
+        - namespace
+        - ${NAMESPACE}
+        - openshift.io/sa.scc.supplemental-groups=3000/1000
+        - --overwrite
+        entrypoint: kubectl
+    - apply:
+        file: 00-otel-filelog.yaml
+    - assert:
+        file: 00-assert.yaml
+  - name: step-01
+    try:
+    - apply:
+        file: 01-app-plaintext-logs.yaml
+    - assert:
+        file: 01-assert.yaml
+  - name: Wait for the metrics, logs to be collected
+    try:
+    - sleep:
+        duration: 60s
+  - name: Check the collected logs
+    try:
+    - script:
+        timeout: 5m
+        content: ./check_logs.sh

--- a/tests/e2e-otel/filelog/check_logs.sh
+++ b/tests/e2e-otel/filelog/check_logs.sh
@@ -1,0 +1,67 @@
+
+#!/bin/bash
+# This script checks the OpenTelemetry collector pod for the presence of Logs.
+
+# Define the label selector
+LABEL_SELECTOR="app.kubernetes.io/component=opentelemetry-collector"
+
+# Define the search strings
+SEARCH_STRING1='-> log.file.name: Str(app-log-plaintext.log)'
+SEARCH_STRING2='-> logger: Str(SVTLogger)'
+SEARCH_STRING3='-> message: Str('
+SEARCH_STRING4='-> time: Str('
+SEARCH_STRING5='-> sev: Str(INFO)'
+SEARCH_STRING6='Body: Str(.*SVTLogger - INFO - app-log-plaintext-'
+
+# Get the list of pods with the specified label
+PODS=$(kubectl -n $NAMESPACE get pods -l $LABEL_SELECTOR -o jsonpath='{.items[*].metadata.name}')
+
+# Initialize flags to track if strings are found
+FOUND1=false
+FOUND2=false
+FOUND3=false
+FOUND4=false
+FOUND5=false
+FOUND6=false
+
+# Loop through each pod and search for the strings in the logs
+for POD in $PODS; do
+    # Search for the first string
+    if ! $FOUND1 && kubectl -n $NAMESPACE --tail=100 logs $POD | grep -q -- "$SEARCH_STRING1"; then
+        echo "\"$SEARCH_STRING1\" found in $POD"
+        FOUND1=true
+    fi
+    # Search for the second string
+    if ! $FOUND2 && kubectl -n $NAMESPACE --tail=100 logs $POD | grep -q -- "$SEARCH_STRING2"; then
+        echo "\"$SEARCH_STRING2\" found in $POD"
+        FOUND2=true
+    fi
+    # Search for the third string
+    if ! $FOUND3 && kubectl -n $NAMESPACE --tail=100 logs $POD | grep -q -- "$SEARCH_STRING3"; then
+        echo "\"$SEARCH_STRING3\" found in $POD"
+        FOUND3=true
+    fi
+    # Search for the fourth string
+    if ! $FOUND4 && kubectl -n $NAMESPACE --tail=100 logs $POD | grep -q -- "$SEARCH_STRING4"; then
+        echo "\"$SEARCH_STRING4\" found in $POD"
+        FOUND4=true
+    fi
+    # Search for the fifth string
+    if ! $FOUND5 && kubectl -n $NAMESPACE --tail=100 logs $POD | grep -q -- "$SEARCH_STRING5"; then
+        echo "\"$SEARCH_STRING5\" found in $POD"
+        FOUND5=true
+    fi
+    # Search for the sixth string
+    if ! $FOUND6 && kubectl -n $NAMESPACE --tail=100 logs $POD | grep -q -- "$SEARCH_STRING6"; then
+        echo "\"$SEARCH_STRING6\" found in $POD"
+        FOUND6=true
+    fi
+done
+
+# Check if any of the strings was not found
+if ! $FOUND1 || ! $FOUND2 || ! $FOUND3 || ! $FOUND4 || ! $FOUND5 || ! $FOUND6; then
+    echo "No logs found for app-log-plaintext.log in collector"
+    exit 1
+else
+    echo "Found logs for app-log-plaintext.log in collector."
+fi

--- a/tests/e2e-otel/filestorageext/app-plaintest-logs-assert.yaml
+++ b/tests/e2e-otel/filestorageext/app-plaintest-logs-assert.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  labels:
+    run: otel-logtest-plaintext
+    test: otel-logtest-plaintext
+  name: app-log-plaintext-rc
+status:
+  availableReplicas: 1
+  readyReplicas: 1
+  replicas: 1
+
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    containerType.logging.openshift.io/app-log-plaintext: app-log-plaintext
+    sidecar.opentelemetry.io/inject: "true"
+  labels:
+    run: otel-logtest-plaintext
+status:
+  phase: Running

--- a/tests/e2e-otel/filestorageext/app-plaintest-logs.yaml
+++ b/tests/e2e-otel/filestorageext/app-plaintest-logs.yaml
@@ -1,0 +1,63 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: app-log-plaintext-config
+data:
+  ocp_logtest.cfg: --rate 60.0 -o /log-data/app-log-plaintext.log
+
+---
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  labels:
+    run: otel-logtest-plaintext
+    test: otel-logtest-plaintext
+  name: app-log-plaintext-rc
+spec:
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        containerType.logging.openshift.io/app-log-plaintext: app-log-plaintext
+        sidecar.opentelemetry.io/inject: "true"
+      generateName: otel-logtest-
+      labels:
+        run: otel-logtest-plaintext
+        test: otel-logtest-plaintext
+    spec:
+      containers:
+      - env: []
+        image: quay.io/openshifttest/ocp-logtest@sha256:6e2973d7d454ce412ad90e99ce584bf221866953da42858c4629873e53778606
+        imagePullPolicy: IfNotPresent
+        name: app-log-plaintext
+        resources: {}
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
+          privileged: false
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+        terminationMessagePath: /dev/termination-log
+        volumeMounts:
+        - mountPath: /log-data
+          name: log-data
+        - mountPath: /var/lib/svt
+          name: config
+        - mountPath: /filestorageext/data
+          name: filestorageext
+        - mountPath: /filestorageext/compaction
+          name: filestorageext
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      volumes:
+      - configMap:
+          name: app-log-plaintext-config
+        name: config
+      - name: log-data
+        emptyDir: {}
+      - name: filestorageext
+        emptyDir: {}

--- a/tests/e2e-otel/filestorageext/chainsaw-test.yaml
+++ b/tests/e2e-otel/filestorageext/chainsaw-test.yaml
@@ -1,0 +1,58 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: filestorageext
+spec:
+  steps:
+  - name: Create OTEL collector with filestorage extension
+    try:
+    - command:
+        args:
+        - -n
+        - $NAMESPACE
+        - create
+        - rolebinding
+        - default-view-$NAMESPACE
+        - --role=pod-view
+        - --serviceaccount=$NAMESPACE:ta
+        entrypoint: kubectl
+    - command:
+        args:
+        - annotate
+        - namespace
+        - ${NAMESPACE}
+        - openshift.io/sa.scc.uid-range=1000/1000
+        - --overwrite
+        entrypoint: kubectl
+    - command:
+        args:
+        - annotate
+        - namespace
+        - ${NAMESPACE}
+        - openshift.io/sa.scc.supplemental-groups=3000/1000
+        - --overwrite
+        entrypoint: kubectl
+    - apply:
+        file: otel-filestorageext.yaml
+    - assert:
+        file: otel-filestorageext-assert.yaml
+  - name: Create the logs generator app
+    try:
+    - apply:
+        file: app-plaintest-logs.yaml
+    - assert:
+        file: app-plaintest-logs-assert.yaml
+  - name: Wait for the logs to be collected
+    try:
+    - sleep:
+        duration: 10s
+  - name: Check the collected logs
+    try:
+    - script:
+        timeout: 5m
+        content: ./check_logs.sh
+  - name: Confirm the filestorage extension is working
+    try:
+    - script:
+        timeout: 5m
+        content: ./check_filestorageext.sh

--- a/tests/e2e-otel/filestorageext/check_filestorageext.sh
+++ b/tests/e2e-otel/filestorageext/check_filestorageext.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# Define the directories to check
+directories=("/filestorageext/compaction" "/filestorageext/data")
+
+# Define the file to check
+file="receiver_filelog_"
+
+# Initialize a variable to keep track of the number of files found
+files_found=0
+
+# Keep running the loop until all files are found
+while [ "$files_found" -ne "${#directories[@]}" ]; do
+  # Reset the counter
+  files_found=0
+
+  # Loop through the directories
+  for dir in "${directories[@]}"; do
+    # Use oc exec to run ls in the directory and grep for the file
+    if oc exec -n $NAMESPACE replicationcontrollers/app-log-plaintext-rc -- ls "$dir" | grep -q "$file"; then
+      echo "File $file found in $dir"
+      ((files_found++))
+    else
+      echo "File $file not found in $dir"
+    fi
+  done
+
+  # Sleep for a while before the next iteration
+  sleep 2
+done
+
+echo "All files found!"

--- a/tests/e2e-otel/filestorageext/check_logs.sh
+++ b/tests/e2e-otel/filestorageext/check_logs.sh
@@ -1,0 +1,67 @@
+
+#!/bin/bash
+# This script checks the OpenTelemetry collector pod for the presence of Logs.
+
+# Define the label selector
+LABEL_SELECTOR="app.kubernetes.io/component=opentelemetry-collector"
+
+# Define the search strings
+SEARCH_STRING1='-> log.file.name: Str(app-log-plaintext.log)'
+SEARCH_STRING2='-> logger: Str(SVTLogger)'
+SEARCH_STRING3='-> message: Str('
+SEARCH_STRING4='-> time: Str('
+SEARCH_STRING5='-> sev: Str(INFO)'
+SEARCH_STRING6='Body: Str(.*SVTLogger - INFO - app-log-plaintext-'
+
+# Get the list of pods with the specified label
+PODS=$(kubectl -n $NAMESPACE get pods -l $LABEL_SELECTOR -o jsonpath='{.items[*].metadata.name}')
+
+# Initialize flags to track if strings are found
+FOUND1=false
+FOUND2=false
+FOUND3=false
+FOUND4=false
+FOUND5=false
+FOUND6=false
+
+# Loop through each pod and search for the strings in the logs
+for POD in $PODS; do
+    # Search for the first string
+    if ! $FOUND1 && kubectl -n $NAMESPACE --tail=100 logs $POD | grep -q -- "$SEARCH_STRING1"; then
+        echo "\"$SEARCH_STRING1\" found in $POD"
+        FOUND1=true
+    fi
+    # Search for the second string
+    if ! $FOUND2 && kubectl -n $NAMESPACE --tail=100 logs $POD | grep -q -- "$SEARCH_STRING2"; then
+        echo "\"$SEARCH_STRING2\" found in $POD"
+        FOUND2=true
+    fi
+    # Search for the third string
+    if ! $FOUND3 && kubectl -n $NAMESPACE --tail=100 logs $POD | grep -q -- "$SEARCH_STRING3"; then
+        echo "\"$SEARCH_STRING3\" found in $POD"
+        FOUND3=true
+    fi
+    # Search for the fourth string
+    if ! $FOUND4 && kubectl -n $NAMESPACE --tail=100 logs $POD | grep -q -- "$SEARCH_STRING4"; then
+        echo "\"$SEARCH_STRING4\" found in $POD"
+        FOUND4=true
+    fi
+    # Search for the fifth string
+    if ! $FOUND5 && kubectl -n $NAMESPACE --tail=100 logs $POD | grep -q -- "$SEARCH_STRING5"; then
+        echo "\"$SEARCH_STRING5\" found in $POD"
+        FOUND5=true
+    fi
+    # Search for the sixth string
+    if ! $FOUND6 && kubectl -n $NAMESPACE --tail=100 logs $POD | grep -q -- "$SEARCH_STRING6"; then
+        echo "\"$SEARCH_STRING6\" found in $POD"
+        FOUND6=true
+    fi
+done
+
+# Check if any of the strings was not found
+if ! $FOUND1 || ! $FOUND2 || ! $FOUND3 || ! $FOUND4 || ! $FOUND5 || ! $FOUND6; then
+    echo "No logs found for app-log-plaintext.log in collector"
+    exit 1
+else
+    echo "Found logs for app-log-plaintext.log in collector."
+fi

--- a/tests/e2e-otel/filestorageext/otel-filestorageext-assert.yaml
+++ b/tests/e2e-otel/filestorageext/otel-filestorageext-assert.yaml
@@ -1,0 +1,68 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: filestorageext-collector
+status:
+  availableReplicas: 1
+  readyReplicas: 1
+  replicas: 1
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: filestorageext-collector
+spec:
+  ports:
+  - appProtocol: grpc
+    name: otlp-grpc
+    port: 4317
+    protocol: TCP
+    targetPort: 4317
+  - appProtocol: http
+    name: otlp-http
+    port: 4318
+    protocol: TCP
+    targetPort: 4318
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: filestorageext-collector-headless
+spec:
+  ports:
+  - appProtocol: grpc
+    name: otlp-grpc
+    port: 4317
+    protocol: TCP
+    targetPort: 4317
+  - appProtocol: http
+    name: otlp-http
+    port: 4318
+    protocol: TCP
+    targetPort: 4318
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: filestorageext-collector-monitoring
+spec:
+  ports:
+  - name: monitoring
+    port: 8888
+    protocol: TCP
+    targetPort: 8888
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: filestorageext-sidecar-collector-monitoring
+spec:
+  ports:
+  - name: monitoring
+    port: 8888
+    protocol: TCP
+    targetPort: 8888

--- a/tests/e2e-otel/filestorageext/otel-filestorageext.yaml
+++ b/tests/e2e-otel/filestorageext/otel-filestorageext.yaml
@@ -1,0 +1,72 @@
+apiVersion: opentelemetry.io/v1alpha1
+kind: OpenTelemetryCollector
+metadata:
+  name: filestorageext
+spec:
+  mode: deployment
+  config: |
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+          http:
+    processors:
+    exporters:
+      debug:
+        verbosity: detailed
+    service:
+      pipelines:
+        logs:
+          receivers: [otlp]
+          processors: []
+          exporters: [debug]
+
+---
+apiVersion: opentelemetry.io/v1alpha1
+kind: OpenTelemetryCollector
+metadata:
+  name: filestorageext-sidecar
+spec:
+  mode: sidecar
+  config: |
+    receivers:
+      filelog:
+        storage: file_storage
+        include: [ /log-data/*.log ]
+        operators:
+          - type: regex_parser
+            regex: '^(?P<time>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3}) - (?P<logger>\S+) - (?P<sev>\S+) - (?P<message>.*)$'
+            timestamp:
+              parse_from: attributes.time
+              layout: '%Y-%m-%d %H:%M:%S'
+            severity:
+              parse_from: attributes.sev
+    processors:
+    exporters:
+      otlp:
+        endpoint: filestorageext-collector:4317
+        tls:
+          insecure: true
+    extensions:
+      file_storage:
+        directory: /filestorageext/data
+        timeout: 1s
+        compaction:
+          on_start: true
+          directory: /filestorageext/compaction
+          max_transaction_size: 65_536
+        fsync: true
+    service:
+      extensions: [file_storage]
+      pipelines:
+        logs:
+          receivers: [filelog]
+          processors: []
+          exporters: [otlp]
+  volumeMounts:
+  - name: log-data
+    mountPath: /log-data
+  - name: filestorageext
+    mountPath: /filestorageext/data
+  - name: filestorageext
+    mountPath: /filestorageext/compaction

--- a/tests/e2e-otel/forwardconnector/chainsaw-test.yaml
+++ b/tests/e2e-otel/forwardconnector/chainsaw-test.yaml
@@ -1,0 +1,28 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: forwardconnector
+spec:
+  namespace: chainsaw-forwardconnector
+  steps:
+  - name: Create OTEL collector with forward connector
+    try:
+    - apply:
+        file: otel-forward-connector.yaml
+    - assert:
+        file: otel-forward-connector-assert.yaml
+  - name: Generate traces
+    try:
+    - apply:
+        file: generate-traces.yaml
+    - assert:
+        file: generate-traces-assert.yaml
+  - name: Wait for the traces to be collected
+    try:
+    - sleep:
+        duration: 10s
+  - name: Check traces in the collector pods
+    try:
+    - script:
+        timeout: 5m
+        content: ./check_logs.sh 

--- a/tests/e2e-otel/forwardconnector/check_logs.sh
+++ b/tests/e2e-otel/forwardconnector/check_logs.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# This script checks the OpenTelemetry collector pod for the presence of Logs.
+
+# Define the label selector
+LABEL_SELECTOR="app.kubernetes.io/component=opentelemetry-collector"
+NAMESPACE=chainsaw-forwardconnector
+
+# Define the search strings
+SEARCH_STRING1='otel_pipeline_tag: Str(blue)'
+SEARCH_STRING2='otel_pipeline_tag: Str(green)'
+SEARCH_STRING3='Name           : lets-go'
+SEARCH_STRING4='Name           : okey-dokey'
+
+# Get the list of pods with the specified label
+PODS=($(kubectl -n $NAMESPACE get pods -l $LABEL_SELECTOR -o jsonpath='{.items[*].metadata.name}'))
+
+# Initialize flags to track if strings are found
+FOUND1=false
+FOUND2=false
+FOUND3=false
+FOUND4=false
+
+# Loop through each pod and search for the strings in the logs
+for POD in "${PODS[@]}"; do
+    # Search for the first string
+    if ! $FOUND1 && kubectl -n $NAMESPACE --tail=400 logs $POD | grep -q -- "$SEARCH_STRING1"; then
+        echo "\"$SEARCH_STRING1\" found in $POD"
+        FOUND1=true
+    fi
+    # Search for the second string
+    if ! $FOUND2 && kubectl -n $NAMESPACE --tail=400 logs $POD | grep -q -- "$SEARCH_STRING2"; then
+        echo "\"$SEARCH_STRING2\" found in $POD"
+        FOUND2=true
+    fi
+    # Search for the third string
+    if ! $FOUND3 && kubectl -n $NAMESPACE --tail=400 logs $POD | grep -q -- "$SEARCH_STRING3"; then
+        echo "\"$SEARCH_STRING3\" found in $POD"
+        FOUND3=true
+    fi
+    # Search for the fourth string
+    if ! $FOUND4 && kubectl -n $NAMESPACE --tail=400 logs $POD | grep -q -- "$SEARCH_STRING4"; then
+        echo "\"$SEARCH_STRING4\" found in $POD"
+        FOUND4=true
+    fi
+done
+
+# Check if any of the strings was not found
+if ! $FOUND1 || ! $FOUND2 || ! $FOUND3 || ! $FOUND4; then
+    echo "No Traces found in OpenTelemetry collector"
+    exit 1
+else
+    echo "Found all the Traces in OpenTelemetry collector."
+fi

--- a/tests/e2e-otel/forwardconnector/generate-traces-assert.yaml
+++ b/tests/e2e-otel/forwardconnector/generate-traces-assert.yaml
@@ -1,0 +1,14 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: generate-traces-http-blue
+status:
+  succeeded: 1
+
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: generate-traces-http-green
+status:
+  succeeded: 1

--- a/tests/e2e-otel/forwardconnector/generate-traces.yaml
+++ b/tests/e2e-otel/forwardconnector/generate-traces.yaml
@@ -1,0 +1,40 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: generate-traces-http-blue
+spec:
+  template:
+    spec:
+      containers:
+      - name: telemetrygen-blue
+        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
+        args:
+        - traces
+        - --otlp-endpoint=otlp-forward-connector-collector:4318
+        - --traces=10
+        - --otlp-http
+        - --otlp-insecure=true
+        - --service=telemetrygen-http-blue
+        - --otlp-attributes=protocol="otlp-http-blue"
+      restartPolicy: Never
+
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: generate-traces-http-green
+spec:
+  template:
+    spec:
+      containers:
+      - name: telemetrygen-green
+        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
+        args:
+        - traces
+        - --otlp-endpoint=otlp-forward-connector-collector:4319
+        - --traces=10
+        - --otlp-http
+        - --otlp-insecure=true
+        - --service=telemetrygen-http-green
+        - --otlp-attributes=protocol="otlp-http-green"
+      restartPolicy: Never

--- a/tests/e2e-otel/forwardconnector/otel-forward-connector-assert.yaml
+++ b/tests/e2e-otel/forwardconnector/otel-forward-connector-assert.yaml
@@ -1,0 +1,31 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: otlp-forward-connector-collector
+status:
+  availableReplicas: 1
+  readyReplicas: 1
+  replicas: 1
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: otlp-forward-connector-collector
+spec:
+  ports:
+  - appProtocol: http
+    name: otlp-blue-http
+    port: 4318
+    protocol: TCP
+    targetPort: 4318
+  - appProtocol: http
+    name: otlp-green-http
+    port: 4319
+    protocol: TCP
+    targetPort: 4319
+  selector:
+    app.kubernetes.io/component: opentelemetry-collector
+    app.kubernetes.io/instance: chainsaw-forwardconnector.otlp-forward-connector
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/part-of: opentelemetry

--- a/tests/e2e-otel/forwardconnector/otel-forward-connector.yaml
+++ b/tests/e2e-otel/forwardconnector/otel-forward-connector.yaml
@@ -1,0 +1,46 @@
+apiVersion: opentelemetry.io/v1alpha1
+kind: OpenTelemetryCollector
+metadata:
+  name: otlp-forward-connector
+spec:
+  mode: deployment
+  config: |
+    receivers:
+      otlp/blue:
+        protocols:
+          http:
+      otlp/green:
+        protocols:
+          http:
+            endpoint: 0.0.0.0:4319
+    processors:
+      attributes/blue:
+        actions:
+        - key: otel_pipeline_tag
+          value: "blue"
+          action: insert
+      attributes/green:
+        actions:
+        - key: otel_pipeline_tag
+          value: "green"
+          action: insert
+      batch:
+    exporters:
+      debug:
+        verbosity: detailed
+    connectors:
+      forward:
+    service:
+      pipelines:
+        traces/blue:
+          receivers: [otlp/blue]
+          processors: [attributes/blue]
+          exporters: [forward]
+        traces/green:
+          receivers: [otlp/green]
+          processors: [attributes/green]
+          exporters: [forward]
+        traces:
+          receivers: [forward]
+          processors: [batch]
+          exporters: [debug]

--- a/tests/e2e-otel/groupbyattrsprocessor/chainsaw-test.yaml
+++ b/tests/e2e-otel/groupbyattrsprocessor/chainsaw-test.yaml
@@ -1,0 +1,33 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: groupbyattrsprocessor
+spec:
+  namespace: chainsaw-gba
+  description: 
+  steps:
+  - name: Enable user workload monitoring
+    try:
+    - apply:
+        file: workload-monitoring.yaml
+    - assert:
+        file: workload-monitoring-assert.yaml
+  - name: Create OTEl collector with kubletstats receiver
+    try:
+    - apply:
+        file: otel-collector.yaml
+    - assert:
+        file: otel-collector-assert.yaml
+  - name: Create OTEL collector with groupbyattrs processor
+    try:
+    - apply:
+        file: otel-groupbyattributes.yaml
+    - assert:
+        file: otel-groupbyattributes-assert.yaml
+  - name: Check the groupbyattrs metrics
+    try:
+    - apply:
+        file: monitoring-view-role.yaml
+    - script:
+        timeout: 5m
+        content: ./check_metrics.sh

--- a/tests/e2e-otel/groupbyattrsprocessor/check_metrics.sh
+++ b/tests/e2e-otel/groupbyattrsprocessor/check_metrics.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+TOKEN=$(oc create token prometheus-user-workload -n openshift-user-workload-monitoring)
+THANOS_QUERIER_HOST=$(oc get route thanos-querier -n openshift-monitoring -o json | jq -r '.spec.host')
+
+#Check metrics for OpenTelemetry collector instance.
+metrics="otelcol_processor_groupbyattrs_metric_groups_sum otelcol_processor_groupbyattrs_num_non_grouped_metrics otelcol_processor_groupbyattrs_metric_groups_bucket otelcol_processor_groupbyattrs_metric_groups_count"
+
+for metric in $metrics; do
+query="$metric"
+count=0
+
+# Keep fetching and checking the metrics until metrics with value is present.
+while [[ $count -eq 0 ]]; do
+    response=$(curl -k -H "Authorization: Bearer $TOKEN" -H "Content-type: application/json" "https://$THANOS_QUERIER_HOST/api/v1/query?query=$query")
+    count=$(echo "$response" | jq -r '.data.result | length')
+
+    if [[ $count -eq 0 ]]; then
+    echo "No metric '$metric' with value present. Retrying..."
+    sleep 5  # Wait for 5 seconds before retrying
+    else
+    echo "Metric '$metric' with value is present."
+    fi
+  done
+done
+

--- a/tests/e2e-otel/groupbyattrsprocessor/monitoring-view-role.yaml
+++ b/tests/e2e-otel/groupbyattrsprocessor/monitoring-view-role.yaml
@@ -1,0 +1,23 @@
+# Add the clusterrole and rolebinding required for fetching metrics from Thanos querier. Refer https://issues.redhat.com/browse/MON-3379
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: chainsaw-gba
+rules:
+- apiGroups: ["monitoring.coreos.com"]
+  resources: ["prometheuses/api"]
+  verbs: ["get", "list", "watch"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: chainsaw-gba
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: chainsaw-gba
+subjects:
+- kind: ServiceAccount
+  name: prometheus-user-workload
+  namespace: openshift-user-workload-monitoring

--- a/tests/e2e-otel/groupbyattrsprocessor/otel-collector-assert.yaml
+++ b/tests/e2e-otel/groupbyattrsprocessor/otel-collector-assert.yaml
@@ -1,0 +1,64 @@
+apiVersion: project.openshift.io/v1
+kind: Project
+metadata:
+  name: chainsaw-gba
+status:
+  phase: Active
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: chainsaw-gba
+  namespace: chainsaw-gba
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: chainsaw-gba-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes/stats
+  verbs:
+  - get
+  - watch
+  - list
+- apiGroups:
+  - ""
+  resources:
+  - nodes/proxy
+  verbs:
+  - get
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: chainsaw-gba-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: chainsaw-gba-role
+subjects:
+- kind: ServiceAccount
+  name: chainsaw-gba
+  namespace: chainsaw-gba
+
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: chainsaw-gba-collector
+  namespace: chainsaw-gba
+spec:
+  updateStrategy:
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+    type: RollingUpdate
+status:
+  numberMisscheduled: 0
+  (desiredNumberScheduled == numberReady): true

--- a/tests/e2e-otel/groupbyattrsprocessor/otel-collector.yaml
+++ b/tests/e2e-otel/groupbyattrsprocessor/otel-collector.yaml
@@ -1,0 +1,69 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: chainsaw-gba
+  namespace: chainsaw-gba
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: chainsaw-gba-role
+rules:
+  - apiGroups: ['']
+    resources: ['nodes/stats']
+    verbs: ['get', 'watch', 'list']
+  - apiGroups: [""]
+    resources: ["nodes/proxy"]
+    verbs: ["get"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: chainsaw-gba-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: chainsaw-gba-role
+subjects:
+  - kind: ServiceAccount
+    name: chainsaw-gba
+    namespace: chainsaw-gba
+
+---
+apiVersion: opentelemetry.io/v1alpha1
+kind: OpenTelemetryCollector
+metadata:
+  name: chainsaw-gba
+  namespace: chainsaw-gba
+spec:
+  mode: daemonset
+  serviceAccount: chainsaw-gba
+  serviceAccountName: chainsaw-gba
+  env:
+  - name: K8S_NODE_NAME
+    valueFrom:
+      fieldRef:
+        fieldPath: spec.nodeName
+  config: |
+    receivers:
+      kubeletstats:
+        collection_interval: 20s
+        auth_type: "serviceAccount"
+        endpoint: "https://${env:K8S_NODE_NAME}:10250"
+        insecure_skip_verify: true
+    exporters:
+      otlp:
+        endpoint: gba-main-collector.chainsaw-gba.svc:4317
+        tls:
+          insecure: true
+    service:
+      pipelines:
+        metrics:
+          receivers: [kubeletstats]
+          exporters: [otlp]
+  tolerations:
+  - key: node-role.kubernetes.io/master
+    operator: Exists
+    effect: NoSchedule

--- a/tests/e2e-otel/groupbyattrsprocessor/otel-groupbyattributes-assert.yaml
+++ b/tests/e2e-otel/groupbyattrsprocessor/otel-groupbyattributes-assert.yaml
@@ -1,0 +1,32 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gba-main-collector
+  namespace: chainsaw-gba
+status:
+  availableReplicas: 1
+  readyReplicas: 1
+  replicas: 1
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: gba-main-collector
+  namespace: chainsaw-gba
+spec:
+  ports:
+  - appProtocol: grpc
+    name: otlp-grpc
+    port: 4317
+    protocol: TCP
+    targetPort: 4317
+  - name: prometheus
+    port: 8889
+    protocol: TCP
+    targetPort: 8889
+  selector:
+    app.kubernetes.io/component: opentelemetry-collector
+    app.kubernetes.io/instance: chainsaw-gba.gba-main
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/part-of: opentelemetry

--- a/tests/e2e-otel/groupbyattrsprocessor/otel-groupbyattributes.yaml
+++ b/tests/e2e-otel/groupbyattrsprocessor/otel-groupbyattributes.yaml
@@ -1,0 +1,38 @@
+apiVersion: opentelemetry.io/v1alpha1
+kind: OpenTelemetryCollector
+metadata:
+  name: gba-main
+  namespace: chainsaw-gba
+spec:
+  mode: deployment
+  observability:
+    metrics:
+      enableMetrics: true
+  config: |
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+    processors:
+      groupbyattrs:
+        keys:
+        - k8s.namespace.name
+        - k8s.container.name
+        - k8s.pod.name
+      batch:
+      attributes:
+        actions:
+          - key: otelpipeline
+            value: gba
+            action: insert
+    exporters:
+      prometheus:
+        endpoint: 0.0.0.0:8889
+        resource_to_telemetry_conversion:
+          enabled: true # by default resource attributes are dropped
+    service:
+      pipelines:
+        metrics:
+          receivers: [otlp]
+          processors: [attributes, batch, groupbyattrs]
+          exporters: [prometheus]

--- a/tests/e2e-otel/groupbyattrsprocessor/workload-monitoring-assert.yaml
+++ b/tests/e2e-otel/groupbyattrsprocessor/workload-monitoring-assert.yaml
@@ -1,0 +1,28 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prometheus-operator
+  namespace: openshift-user-workload-monitoring
+(status.replicas == spec.replicas): true
+spec:
+  (replicas >= `1`): true
+
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: prometheus-user-workload
+  namespace: openshift-user-workload-monitoring
+(status.replicas == spec.replicas): true
+spec:
+  (replicas >= `1`): true
+
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: thanos-ruler-user-workload
+  namespace: openshift-user-workload-monitoring
+(status.replicas == spec.replicas): true
+spec:
+  (replicas >= `1`): true

--- a/tests/e2e-otel/groupbyattrsprocessor/workload-monitoring.yaml
+++ b/tests/e2e-otel/groupbyattrsprocessor/workload-monitoring.yaml
@@ -1,0 +1,11 @@
+# oc -n openshift-user-workload-monitoring get pod
+# https://docs.openshift.com/container-platform/4.13/monitoring/enabling-monitoring-for-user-defined-projects.html#accessing-metrics-from-outside-cluster_enabling-monitoring-for-user-defined-projects
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-monitoring-config
+  namespace: openshift-monitoring
+data:
+  config.yaml: |
+    enableUserWorkload: true 

--- a/tests/e2e-otel/hostmetricsreceiver/chainsaw-test.yaml
+++ b/tests/e2e-otel/hostmetricsreceiver/chainsaw-test.yaml
@@ -1,0 +1,22 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: hostmetricsreceiver
+spec:
+  namespace: chainsaw-hostmetrics
+  steps:
+  - name: Create OTEL collector with hostmetricsreceiver receiver
+    try:
+    - apply:
+        file: otel-hostmetricsreceiver.yaml
+    - assert:
+        file: otel-hostmetricsreceiver-assert.yaml
+  - name: Wait for the metrics to be collected
+    try:
+    - sleep:
+        duration: 10s
+  - name: Check some of the metrics in the OTEl collector
+    try:
+    - script:
+        timeout: 5m
+        content: ./check_logs.sh 

--- a/tests/e2e-otel/hostmetricsreceiver/check_logs.sh
+++ b/tests/e2e-otel/hostmetricsreceiver/check_logs.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# This script checks the OpenTelemetry collector pod for the presence of Logs.
+
+# Define the label selector
+LABEL_SELECTOR="app.kubernetes.io/component=opentelemetry-collector"
+NAMESPACE=chainsaw-hostmetrics
+
+# Define the search strings
+SEARCH_STRING1='process.pid'
+SEARCH_STRING2='process.parent_pid'
+SEARCH_STRING3='process.executable.name'
+SEARCH_STRING4='process.executable.path'
+SEARCH_STRING5='process.command'
+
+# Initialize flags to track if strings are found
+FOUND1=false
+FOUND2=false
+FOUND3=false
+FOUND4=false
+FOUND5=false
+
+# Loop until all strings are found
+while ! $FOUND1 || ! $FOUND2 || ! $FOUND3 || ! $FOUND4 || ! $FOUND5; do
+    # Get the list of pods with the specified label
+    PODS=($(kubectl -n $NAMESPACE get pods -l $LABEL_SELECTOR -o jsonpath='{.items[*].metadata.name}'))
+    
+    # Loop through each pod and search for the strings in the logs
+    for POD in "${PODS[@]}"; do
+        # Search for the first string
+        if ! $FOUND1 && kubectl -n $NAMESPACE --tail=500 logs $POD | grep -q -- "$SEARCH_STRING1"; then
+            echo "\"$SEARCH_STRING1\" found in $POD"
+            FOUND1=true
+        fi
+        # Search for the second string
+        if ! $FOUND2 && kubectl -n $NAMESPACE --tail=500 logs $POD | grep -q -- "$SEARCH_STRING2"; then
+            echo "\"$SEARCH_STRING2\" found in $POD"
+            FOUND2=true
+        fi
+        # Search for the third string
+        if ! $FOUND3 && kubectl -n $NAMESPACE --tail=500 logs $POD | grep -q -- "$SEARCH_STRING3"; then
+            echo "\"$SEARCH_STRING3\" found in $POD"
+            FOUND3=true
+        fi
+        # Search for the fourth string
+        if ! $FOUND4 && kubectl -n $NAMESPACE --tail=500 logs $POD | grep -q -- "$SEARCH_STRING4"; then
+            echo "\"$SEARCH_STRING4\" found in $POD"
+            FOUND4=true
+        fi
+        # Search for the fifth string
+        if ! $FOUND5 && kubectl -n $NAMESPACE --tail=500 logs $POD | grep -q -- "$SEARCH_STRING5"; then
+            echo "\"$SEARCH_STRING5\" found in $POD"
+            FOUND5=true
+        fi
+    done
+done
+
+echo "Found all the host metrics in OpenTelemetry collector."

--- a/tests/e2e-otel/hostmetricsreceiver/otel-hostmetricsreceiver-assert.yaml
+++ b/tests/e2e-otel/hostmetricsreceiver/otel-hostmetricsreceiver-assert.yaml
@@ -1,0 +1,32 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: otel-hstmtrs-collector
+  namespace: chainsaw-hostmetrics
+spec:
+  updateStrategy:
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+    type: RollingUpdate
+status:
+  numberMisscheduled: 0
+  (desiredNumberScheduled == numberReady): true
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: otel-hstmtrs-collector-monitoring
+  namespace: chainsaw-hostmetrics
+spec:
+  ports:
+  - name: monitoring
+    port: 8888
+    protocol: TCP
+    targetPort: 8888
+  selector:
+    app.kubernetes.io/component: opentelemetry-collector
+    app.kubernetes.io/instance: chainsaw-hostmetrics.otel-hstmtrs
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/part-of: opentelemetry

--- a/tests/e2e-otel/hostmetricsreceiver/otel-hostmetricsreceiver.yaml
+++ b/tests/e2e-otel/hostmetricsreceiver/otel-hostmetricsreceiver.yaml
@@ -1,0 +1,86 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: otel-hostfs-daemonset
+  namespace: chainsaw-hostmetrics
+
+---
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+allowHostDirVolumePlugin: true
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: true
+allowHostPorts: false
+allowPrivilegeEscalation: true
+allowPrivilegedContainer: true
+allowedCapabilities: null
+defaultAddCapabilities:
+- SYS_ADMIN
+fsGroup:
+  type: RunAsAny
+groups: []
+metadata:
+  name: otel-hostmetrics
+readOnlyRootFilesystem: true
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: RunAsAny
+supplementalGroups:
+  type: RunAsAny
+users:
+- system:serviceaccount:chainsaw-hostmetrics:otel-hostfs-daemonset
+volumes:
+- configMap
+- emptyDir
+- hostPath
+- projected
+
+---
+apiVersion: opentelemetry.io/v1alpha1
+kind: OpenTelemetryCollector
+metadata:
+  name: otel-hstmtrs
+spec:
+  mode: daemonset
+  serviceAccount: otel-hostfs-daemonset
+  serviceAccountName: otel-hostfs-daemonset
+  config: |
+    receivers:
+      hostmetrics:
+        root_path: /hostfs
+        collection_interval: 10s
+        scrapers:
+          cpu:
+          load:
+          memory:
+          disk:
+          filesystem:
+          network:
+          paging:
+          processes:
+          process:
+    processors:
+    exporters:
+      debug:
+        verbosity: detailed
+    service:
+      pipelines:
+        metrics:
+          receivers: [hostmetrics]
+          processors: []
+          exporters: [debug]
+  volumeMounts:
+  - name: hostfs
+    mountPath: /hostfs
+    readOnly: true
+    mountPropagation: HostToContainer
+  volumes:
+  - name: hostfs
+    hostPath:
+      path: /
+  tolerations:
+  - key: node-role.kubernetes.io/master
+    operator: Exists
+    effect: NoSchedule

--- a/tests/e2e-otel/journaldreceiver/00-assert.yaml
+++ b/tests/e2e-otel/journaldreceiver/00-assert.yaml
@@ -1,0 +1,45 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    app.kubernetes.io/component: opentelemetry-collector
+    app.kubernetes.io/instance: chainsaw-journald.otel-joural-logs
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/name: otel-joural-logs-collector
+    app.kubernetes.io/part-of: opentelemetry
+  name: otel-joural-logs-collector
+  namespace: chainsaw-journald
+spec:
+  updateStrategy:
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+    type: RollingUpdate
+status:
+  numberMisscheduled: 0
+  (desiredNumberScheduled == numberReady): true
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: opentelemetry-collector
+    app.kubernetes.io/instance: chainsaw-journald.otel-joural-logs
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/name: otel-joural-logs-collector-monitoring
+    app.kubernetes.io/part-of: opentelemetry
+  name: otel-joural-logs-collector-monitoring
+  namespace: chainsaw-journald
+spec:
+  ports:
+  - name: monitoring
+    port: 8888
+    protocol: TCP
+    targetPort: 8888
+  selector:
+    app.kubernetes.io/component: opentelemetry-collector
+    app.kubernetes.io/instance: chainsaw-journald.otel-joural-logs
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/part-of: opentelemetry
+  type: ClusterIP

--- a/tests/e2e-otel/journaldreceiver/00-otel-journaldreceiver.yaml
+++ b/tests/e2e-otel/journaldreceiver/00-otel-journaldreceiver.yaml
@@ -1,0 +1,85 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: chainsaw-journald
+  labels:
+    security.openshift.io/scc.podSecurityLabelSync: "false"
+    pod-security.kubernetes.io/enforce: "privileged"
+    pod-security.kubernetes.io/audit: "privileged"
+    pod-security.kubernetes.io/warn: "privileged"
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: privileged-sa
+  namespace: chainsaw-journald
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: chainsaw-journald--binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:openshift:scc:privileged
+subjects:
+- kind: ServiceAccount
+  name: privileged-sa
+  namespace: chainsaw-journald
+
+---
+apiVersion: opentelemetry.io/v1alpha1
+kind: OpenTelemetryCollector
+metadata:
+  name: otel-joural-logs
+  namespace: chainsaw-journald
+spec:
+  mode: daemonset
+  serviceAccount: privileged-sa
+  serviceAccountName: privileged-sa
+  securityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+      - CHOWN
+      - DAC_OVERRIDE
+      - FOWNER
+      - FSETID
+      - KILL
+      - NET_BIND_SERVICE
+      - SETGID
+      - SETPCAP
+      - SETUID
+    readOnlyRootFilesystem: true
+    seLinuxOptions:
+      type: spc_t
+    seccompProfile:
+      type: RuntimeDefault
+  config: |
+    receivers:
+      journald:
+        files: /var/log/journal/*/*
+    processors:
+    exporters:
+      debug:
+        verbosity: detailed
+    service:
+      pipelines:
+        logs:
+          receivers: [journald]
+          processors: []
+          exporters: [debug]
+  volumeMounts:
+  - name: journal-logs
+    mountPath: /var/log/journal/
+    readOnly: true
+  volumes:
+  - name: journal-logs
+    hostPath:
+      path: /var/log/journal
+  tolerations:
+  - key: node-role.kubernetes.io/master
+    operator: Exists
+    effect: NoSchedule

--- a/tests/e2e-otel/journaldreceiver/chainsaw-test.yaml
+++ b/tests/e2e-otel/journaldreceiver/chainsaw-test.yaml
@@ -1,0 +1,21 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: journaldreceiver
+spec:
+  steps:
+  - name: step-00
+    try:
+    - apply:
+        file: 00-otel-journaldreceiver.yaml
+    - assert:
+        file: 00-assert.yaml
+  - name: Wait for the journal logs to be collected
+    try:
+    - sleep:
+        duration: 60s
+  - name: step-01
+    try:
+    - script:
+        timeout: 5m
+        content: ./check_logs.sh 

--- a/tests/e2e-otel/journaldreceiver/check_logs.sh
+++ b/tests/e2e-otel/journaldreceiver/check_logs.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+# This script checks the OpenTelemetry collector pod for the presence of Logs.
+
+# Define the label selector
+LABEL_SELECTOR="app.kubernetes.io/component=opentelemetry-collector"
+NAMESPACE=chainsaw-journald
+
+# Define the search strings
+SEARCH_STRING1='_SYSTEMD_UNIT'
+SEARCH_STRING2='_UID'
+SEARCH_STRING3='_HOSTNAME'
+SEARCH_STRING4='_SYSTEMD_INVOCATION_ID'
+SEARCH_STRING5='_SELINUX_CONTEXT'
+
+# Get the list of pods with the specified label
+PODS=($(kubectl -n $NAMESPACE get pods -l $LABEL_SELECTOR -o jsonpath='{.items[*].metadata.name}'))
+
+# Initialize flags to track if strings are found
+FOUND1=false
+FOUND2=false
+FOUND3=false
+FOUND4=false
+FOUND5=false
+
+# Loop through each pod and search for the strings in the logs
+for POD in "${PODS[@]}"; do
+    # Search for the first string
+    if ! $FOUND1 && kubectl -n $NAMESPACE --tail=100 logs $POD | grep -q -- "$SEARCH_STRING1"; then
+        echo "\"$SEARCH_STRING1\" found in $POD"
+        FOUND1=true
+    fi
+    # Search for the second string
+    if ! $FOUND2 && kubectl -n $NAMESPACE --tail=100 logs $POD | grep -q -- "$SEARCH_STRING2"; then
+        echo "\"$SEARCH_STRING2\" found in $POD"
+        FOUND2=true
+    fi
+    # Search for the third string
+    if ! $FOUND3 && kubectl -n $NAMESPACE --tail=100 logs $POD | grep -q -- "$SEARCH_STRING3"; then
+        echo "\"$SEARCH_STRING3\" found in $POD"
+        FOUND3=true
+    fi
+    # Search for the fourth string
+    if ! $FOUND4 && kubectl -n $NAMESPACE --tail=100 logs $POD | grep -q -- "$SEARCH_STRING4"; then
+        echo "\"$SEARCH_STRING4\" found in $POD"
+        FOUND4=true
+    fi
+    # Search for the fifth string
+    if ! $FOUND5 && kubectl -n $NAMESPACE --tail=100 logs $POD | grep -q -- "$SEARCH_STRING5"; then
+        echo "\"$SEARCH_STRING5\" found in $POD"
+        FOUND5=true
+    fi
+done
+
+# Check if any of the strings was not found
+if ! $FOUND1 || ! $FOUND2 || ! $FOUND3 || ! $FOUND4 || ! $FOUND5; then
+    echo "No journal logs found in otel-joural-logs-collector  collector"
+    exit 1
+else
+    echo "Found journal logs in otel-joural-logs-collector in collector."
+fi

--- a/tests/e2e-otel/k8sclusterreceiver/chainsaw-test.yaml
+++ b/tests/e2e-otel/k8sclusterreceiver/chainsaw-test.yaml
@@ -1,0 +1,21 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: k8sclusterreceiver
+spec:
+  steps:
+  - name: Create OTEL collector with k8s_cluster receiver
+    try:
+    - apply:
+        file: otel-k8sclusterreceiver.yaml
+    - assert:
+        file: otel-k8sclusterreceiver-assert.yaml
+  - name: Wait for the metrics, logs to be collected
+    try:
+    - sleep:
+        duration: 60s
+  - name: Check some of the metrics in the OTEl collector
+    try:
+    - script:
+        timeout: 5m
+        content: ./check_logs.sh 

--- a/tests/e2e-otel/k8sclusterreceiver/check_logs.sh
+++ b/tests/e2e-otel/k8sclusterreceiver/check_logs.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# This script checks the OpenTelemetry collector pod for the presence of Logs.
+
+# Define the label selector
+LABEL_SELECTOR="app.kubernetes.io/component=opentelemetry-collector"
+NAMESPACE=chainsaw-k8sclusterreceiver
+
+# Define the search strings
+SEARCH_STRING1='k8s.node.allocatable_cpu'
+SEARCH_STRING2='k8s.node.allocatable_memory'
+SEARCH_STRING3='k8s.node.condition_memory_pressure'
+SEARCH_STRING4='k8s.node.condition_ready'
+
+# Get the list of pods with the specified label
+PODS=($(kubectl -n $NAMESPACE get pods -l $LABEL_SELECTOR -o jsonpath='{.items[*].metadata.name}'))
+
+# Initialize flags to track if strings are found
+FOUND1=false
+FOUND2=false
+FOUND3=false
+FOUND4=false
+
+# Loop until all strings are found
+while ! $FOUND1 || ! $FOUND2 || ! $FOUND3 || ! $FOUND4; do
+    # Get the list of pods with the specified label
+    PODS=($(kubectl -n $NAMESPACE get pods -l $LABEL_SELECTOR -o jsonpath='{.items[*].metadata.name}'))
+    
+    # Loop through each pod and search for the strings in the logs
+    for POD in "${PODS[@]}"; do
+        # Search for the first string
+        if ! $FOUND1 && kubectl -n $NAMESPACE --tail=500 logs $POD | grep -q -- "$SEARCH_STRING1"; then
+            echo "\"$SEARCH_STRING1\" found in $POD"
+            FOUND1=true
+        fi
+        # Search for the second string
+        if ! $FOUND2 && kubectl -n $NAMESPACE --tail=500 logs $POD | grep -q -- "$SEARCH_STRING2"; then
+            echo "\"$SEARCH_STRING2\" found in $POD"
+            FOUND2=true
+        fi
+        # Search for the third string
+        if ! $FOUND3 && kubectl -n $NAMESPACE --tail=500 logs $POD | grep -q -- "$SEARCH_STRING3"; then
+            echo "\"$SEARCH_STRING3\" found in $POD"
+            FOUND3=true
+        fi
+        # Search for the fourth string
+        if ! $FOUND4 && kubectl -n $NAMESPACE --tail=500 logs $POD | grep -q -- "$SEARCH_STRING4"; then
+            echo "\"$SEARCH_STRING4\" found in $POD"
+            FOUND4=true
+        fi
+    done
+done
+
+echo "Found all the Metrics in OpenTelemetry collector."

--- a/tests/e2e-otel/k8sclusterreceiver/otel-k8sclusterreceiver-assert.yaml
+++ b/tests/e2e-otel/k8sclusterreceiver/otel-k8sclusterreceiver-assert.yaml
@@ -1,0 +1,112 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: chainsaw-k8sclusterreceiver
+spec:
+  finalizers:
+  - kubernetes
+status:
+  phase: Active
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: chainsaw-k8sclusterreceiver
+  namespace: chainsaw-k8sclusterreceiver
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: chainsaw-k8sclusterreceiver-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  - namespaces
+  - namespaces/status
+  - nodes
+  - nodes/spec
+  - pods
+  - pods/status
+  - replicationcontrollers
+  - replicationcontrollers/status
+  - resourcequotas
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - daemonsets
+  - deployments
+  - replicasets
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - extensions
+  resources:
+  - daemonsets
+  - deployments
+  - replicasets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  - cronjobs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - quota.openshift.io
+  resources:
+  - clusterresourcequotas
+  verbs:
+  - get
+  - list
+  - watch
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: chainsaw-k8sclusterreceiver-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: chainsaw-k8sclusterreceiver-role
+subjects:
+- kind: ServiceAccount
+  name: chainsaw-k8sclusterreceiver
+  namespace: chainsaw-k8sclusterreceiver
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: chainsaw-k8sclusterreceiver-collector
+  namespace: chainsaw-k8sclusterreceiver
+status:
+  availableReplicas: 1
+  readyReplicas: 1
+  replicas: 1

--- a/tests/e2e-otel/k8sclusterreceiver/otel-k8sclusterreceiver.yaml
+++ b/tests/e2e-otel/k8sclusterreceiver/otel-k8sclusterreceiver.yaml
@@ -1,0 +1,129 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: chainsaw-k8sclusterreceiver
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: chainsaw-k8sclusterreceiver
+  namespace: chainsaw-k8sclusterreceiver
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: chainsaw-k8sclusterreceiver-role
+rules:
+- apiGroups:
+  - ''
+  resources:
+  - events
+  - namespaces
+  - namespaces/status
+  - nodes
+  - nodes/spec
+  - pods
+  - pods/status
+  - replicationcontrollers
+  - replicationcontrollers/status
+  - resourcequotas
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - daemonsets
+  - deployments
+  - replicasets
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - extensions
+  resources:
+  - daemonsets
+  - deployments
+  - replicasets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  - cronjobs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - quota.openshift.io
+  resources:
+  - clusterresourcequotas
+  verbs:
+  - get
+  - list
+  - watch
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: chainsaw-k8sclusterreceiver-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: chainsaw-k8sclusterreceiver-role
+subjects:
+  - kind: ServiceAccount
+    name: chainsaw-k8sclusterreceiver
+    namespace: chainsaw-k8sclusterreceiver
+
+---
+apiVersion: opentelemetry.io/v1alpha1
+kind: OpenTelemetryCollector
+metadata:
+  name: chainsaw-k8sclusterreceiver
+  namespace: chainsaw-k8sclusterreceiver
+spec:
+  mode: deployment
+  serviceAccount: chainsaw-k8sclusterreceiver
+  serviceAccountName: chainsaw-k8sclusterreceiver
+  config: |
+    receivers:
+      k8s_cluster:
+        distribution: openshift
+        collection_interval: 15s
+        node_conditions_to_report:
+          - Ready
+          - MemoryPressure
+        allocatable_types_to_report:
+          - cpu
+          - memory
+    exporters:
+      debug:
+        verbosity: detailed
+    service:
+      pipelines:
+        metrics:
+          receivers: [k8s_cluster]
+          exporters: [debug]
+        logs:
+          receivers: [k8s_cluster]
+          exporters: [debug]

--- a/tests/e2e-otel/k8seventsreceiver/chainsaw-test.yaml
+++ b/tests/e2e-otel/k8seventsreceiver/chainsaw-test.yaml
@@ -1,0 +1,27 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: k8seventsreceiver
+spec:
+  steps:
+  - name: Create OTEL collector with k8s_cluster receiver
+    try:
+    - apply:
+        file: otel-k8seventsreceiver.yaml
+    - assert:
+        file: otel-k8seventsreceiver-assert.yaml
+  - name: Deploy a sample app to generate events
+    try:
+    - apply:
+        file: install-app.yaml
+    - assert:
+        file: install-app-assert.yaml
+  - name: Wait for the event logs to be collected
+    try:
+    - sleep:
+        duration: 60s
+  - name: Check some of the event logs in the OTEl collector
+    try:
+    - script:
+        timeout: 5m
+        content: ./check_logs.sh

--- a/tests/e2e-otel/k8seventsreceiver/check_logs.sh
+++ b/tests/e2e-otel/k8seventsreceiver/check_logs.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+# This script checks the OpenTelemetry collector pod for the presence of Logs.
+
+# Define the label selector
+LABEL_SELECTOR="app.kubernetes.io/component=opentelemetry-collector"
+NAMESPACE=chainsaw-k8seventsreceiver
+
+# Define the search strings
+SEARCH_STRING1='k8s.event.reason'
+SEARCH_STRING2='k8s.event.action'
+SEARCH_STRING3='k8s.event.start_time'
+SEARCH_STRING4='k8s.event.name'
+SEARCH_STRING5='k8s.event.uid'
+SEARCH_STRING6='k8s.namespace.name: Str(chainsaw-k8seventsreceiver)'
+SEARCH_STRING7='k8s.event.count'
+
+# Get the list of pods with the specified label
+PODS=($(kubectl -n $NAMESPACE get pods -l $LABEL_SELECTOR -o jsonpath='{.items[*].metadata.name}'))
+
+# Initialize flags to track if strings are found
+FOUND1=false
+FOUND2=false
+FOUND3=false
+FOUND4=false
+FOUND5=false
+FOUND6=false
+FOUND7=false
+
+# Loop through each pod and search for the strings in the logs
+for POD in "${PODS[@]}"; do
+    # Search for the first string
+    if ! $FOUND1 && kubectl -n $NAMESPACE --tail=200 logs $POD | grep -q -- "$SEARCH_STRING1"; then
+        echo "\"$SEARCH_STRING1\" found in $POD"
+        FOUND1=true
+    fi
+    # Search for the second string
+    if ! $FOUND2 && kubectl -n $NAMESPACE --tail=200 logs $POD | grep -q -- "$SEARCH_STRING2"; then
+        echo "\"$SEARCH_STRING2\" found in $POD"
+        FOUND2=true
+    fi
+    # Search for the third string
+    if ! $FOUND3 && kubectl -n $NAMESPACE --tail=200 logs $POD | grep -q -- "$SEARCH_STRING3"; then
+        echo "\"$SEARCH_STRING3\" found in $POD"
+        FOUND3=true
+    fi
+    # Search for the fourth string
+    if ! $FOUND4 && kubectl -n $NAMESPACE --tail=200 logs $POD | grep -q -- "$SEARCH_STRING4"; then
+        echo "\"$SEARCH_STRING4\" found in $POD"
+        FOUND4=true
+    fi
+    # Search for the fourth string
+    if ! $FOUND5 && kubectl -n $NAMESPACE --tail=200 logs $POD | grep -q -- "$SEARCH_STRING5"; then
+        echo "\"$SEARCH_STRING5\" found in $POD"
+        FOUND5=true
+    fi
+    # Search for the fourth string
+    if ! $FOUND6 && kubectl -n $NAMESPACE --tail=200 logs $POD | grep -q -- "$SEARCH_STRING6"; then
+        echo "\"$SEARCH_STRING6\" found in $POD"
+        FOUND6=true
+    fi
+    # Search for the fourth string
+    if ! $FOUND7 && kubectl -n $NAMESPACE --tail=200 logs $POD | grep -q -- "$SEARCH_STRING7"; then
+        echo "\"$SEARCH_STRING7\" found in $POD"
+        FOUND7=true
+    fi
+done
+
+# Check if any of the strings was not found
+if ! $FOUND1 || ! $FOUND2 || ! $FOUND3 || ! $FOUND4 || ! $FOUND5 || ! $FOUND6 || ! $FOUND7; then
+    echo "No Kubernetes events found in OpenTelemetry collector"
+    exit 1
+else
+    echo "Found all the Kubernetes events in OpenTelemetry collector."
+fi

--- a/tests/e2e-otel/k8seventsreceiver/install-app-assert.yaml
+++ b/tests/e2e-otel/k8seventsreceiver/install-app-assert.yaml
@@ -1,0 +1,7 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hotrod
+  namespace: chainsaw-k8seventsreceiver 
+status:
+  readyReplicas: 1

--- a/tests/e2e-otel/k8seventsreceiver/install-app.yaml
+++ b/tests/e2e-otel/k8seventsreceiver/install-app.yaml
@@ -1,0 +1,41 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hotrod
+  namespace: chainsaw-k8seventsreceiver
+  labels:
+    app: hotrod
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: hotrod
+  template:
+    metadata:
+      labels:
+        app: hotrod
+    spec:
+      containers:
+        - name: hotrod
+          image: jaegertracing/example-hotrod:1.46.0
+          args:
+            - all
+            - --otel-exporter=otlp
+          ports:
+            - containerPort: 8080
+          env:
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: http://chainsaw-k8seventsreceiver-collector:4318
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: hotrod
+  namespace: chainsaw-k8seventsreceiver
+spec:
+  selector:
+    app: hotrod
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8080

--- a/tests/e2e-otel/k8seventsreceiver/otel-k8seventsreceiver-assert.yaml
+++ b/tests/e2e-otel/k8seventsreceiver/otel-k8seventsreceiver-assert.yaml
@@ -1,0 +1,112 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: chainsaw-k8seventsreceiver
+spec:
+  finalizers:
+  - kubernetes
+status:
+  phase: Active
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: chainsaw-k8seventsreceiver
+  namespace: chainsaw-k8seventsreceiver
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: chainsaw-k8seventsreceiver-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  - namespaces
+  - namespaces/status
+  - nodes
+  - nodes/spec
+  - pods
+  - pods/status
+  - replicationcontrollers
+  - replicationcontrollers/status
+  - resourcequotas
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - daemonsets
+  - deployments
+  - replicasets
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - extensions
+  resources:
+  - daemonsets
+  - deployments
+  - replicasets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  - cronjobs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - quota.openshift.io
+  resources:
+  - clusterresourcequotas
+  verbs:
+  - get
+  - list
+  - watch
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: chainsaw-k8seventsreceiver-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: chainsaw-k8seventsreceiver-role
+subjects:
+- kind: ServiceAccount
+  name: chainsaw-k8seventsreceiver
+  namespace: chainsaw-k8seventsreceiver
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: chainsaw-k8seventsreceiver-collector
+  namespace: chainsaw-k8seventsreceiver
+status:
+  availableReplicas: 1
+  readyReplicas: 1
+  replicas: 1

--- a/tests/e2e-otel/k8seventsreceiver/otel-k8seventsreceiver.yaml
+++ b/tests/e2e-otel/k8seventsreceiver/otel-k8seventsreceiver.yaml
@@ -1,0 +1,125 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: chainsaw-k8seventsreceiver
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: chainsaw-k8seventsreceiver
+  namespace: chainsaw-k8seventsreceiver
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: chainsaw-k8seventsreceiver-role
+rules:
+- apiGroups:
+  - ''
+  resources:
+  - events
+  - namespaces
+  - namespaces/status
+  - nodes
+  - nodes/spec
+  - pods
+  - pods/status
+  - replicationcontrollers
+  - replicationcontrollers/status
+  - resourcequotas
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - daemonsets
+  - deployments
+  - replicasets
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - extensions
+  resources:
+  - daemonsets
+  - deployments
+  - replicasets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  - cronjobs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - quota.openshift.io
+  resources:
+  - clusterresourcequotas
+  verbs:
+  - get
+  - list
+  - watch
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: chainsaw-k8seventsreceiver-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: chainsaw-k8seventsreceiver-role
+subjects:
+  - kind: ServiceAccount
+    name: chainsaw-k8seventsreceiver
+    namespace: chainsaw-k8seventsreceiver
+
+---
+apiVersion: opentelemetry.io/v1alpha1
+kind: OpenTelemetryCollector
+metadata:
+  name: chainsaw-k8seventsreceiver
+  namespace: chainsaw-k8seventsreceiver
+spec:
+  mode: deployment
+  serviceAccount: chainsaw-k8seventsreceiver
+  serviceAccountName: chainsaw-k8seventsreceiver
+  config: |
+    receivers:
+      otlp:
+        protocols:
+          http:
+      k8s_events:
+        namespaces: [chainsaw-k8seventsreceiver]
+    exporters:
+      debug:
+        verbosity: detailed
+    service:
+      pipelines:
+        logs:
+          receivers: [k8s_events]
+          exporters: [debug]
+        traces:
+          receivers: [otlp]
+          exporters: [debug]

--- a/tests/e2e-otel/k8sobjectsreceiver/chainsaw-test.yaml
+++ b/tests/e2e-otel/k8sobjectsreceiver/chainsaw-test.yaml
@@ -1,0 +1,21 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: k8sobjectsreceiver
+spec:
+  steps:
+  - name: Create OTEL collector with k8sobjects receiver
+    try:
+    - apply:
+        file: otel-k8sobjectsreceiver.yaml
+    - assert:
+        file: otel-k8sobjectsreceiver-assert.yaml
+  - name: Wait for the event logs to be collected
+    try:
+    - sleep:
+        duration: 10s
+  - name: Check some of the event logs in the OTEl collector
+    try:
+    - script:
+        timeout: 5m
+        content: ./check_logs.sh

--- a/tests/e2e-otel/k8sobjectsreceiver/check_logs.sh
+++ b/tests/e2e-otel/k8sobjectsreceiver/check_logs.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# This script checks the OpenTelemetry collector pod for the presence of Logs.
+
+# Define the label selector
+LABEL_SELECTOR="app.kubernetes.io/component=opentelemetry-collector"
+NAMESPACE=chainsaw-k8sobjectsreceiver
+
+# Define the search strings
+SEARCH_STRING1='Body: Map({"object":'
+SEARCH_STRING2='k8s.resource.name'
+SEARCH_STRING3='event.domain'
+SEARCH_STRING4='event.name'
+
+# Get the list of pods with the specified label
+PODS=($(kubectl -n $NAMESPACE get pods -l $LABEL_SELECTOR -o jsonpath='{.items[*].metadata.name}'))
+
+# Initialize flags to track if strings are found
+FOUND1=false
+FOUND2=false
+FOUND3=false
+FOUND4=false
+
+# Loop through each pod and search for the strings in the logs
+for POD in "${PODS[@]}"; do
+    # Search for the first string
+    if ! $FOUND1 && kubectl -n $NAMESPACE --tail=500 logs $POD | grep -q -- "$SEARCH_STRING1"; then
+        echo "\"$SEARCH_STRING1\" found in $POD"
+        FOUND1=true
+    fi
+    # Search for the second string
+    if ! $FOUND2 && kubectl -n $NAMESPACE --tail=500 logs $POD | grep -q -- "$SEARCH_STRING2"; then
+        echo "\"$SEARCH_STRING2\" found in $POD"
+        FOUND2=true
+    fi
+    # Search for the third string
+    if ! $FOUND3 && kubectl -n $NAMESPACE --tail=500 logs $POD | grep -q -- "$SEARCH_STRING3"; then
+        echo "\"$SEARCH_STRING3\" found in $POD"
+        FOUND3=true
+    fi
+    # Search for the fourth string
+    if ! $FOUND4 && kubectl -n $NAMESPACE --tail=500 logs $POD | grep -q -- "$SEARCH_STRING4"; then
+        echo "\"$SEARCH_STRING4\" found in $POD"
+        FOUND4=true
+    fi
+done
+
+# Check if any of the strings was not found
+if ! $FOUND1 || ! $FOUND2 || ! $FOUND3 || ! $FOUND4; then
+    echo "No Kubernetes events found in OpenTelemetry collector"
+    exit 1
+else
+    echo "Found all the Kubernetes events in OpenTelemetry collector."
+fi

--- a/tests/e2e-otel/k8sobjectsreceiver/otel-k8sobjectsreceiver-assert.yaml
+++ b/tests/e2e-otel/k8sobjectsreceiver/otel-k8sobjectsreceiver-assert.yaml
@@ -1,0 +1,65 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: chainsaw-k8sobjectsreceiver
+spec:
+  finalizers:
+  - kubernetes
+status:
+  phase: Active
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: chainsaw-k8sobjectsreceiver
+  namespace: chainsaw-k8sobjectsreceiver
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: chainsaw-k8sobjectsreceiver-role
+rules:
+- apiGroups:
+  - ''
+  resources:
+  - events
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - get
+  - list
+  - watch
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: chainsaw-k8sobjectsreceiver-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: chainsaw-k8sobjectsreceiver-role
+subjects:
+  - kind: ServiceAccount
+    name: chainsaw-k8sobjectsreceiver
+    namespace: chainsaw-k8sobjectsreceiver
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: chainsaw-k8sobjectsreceiver-collector
+  namespace: chainsaw-k8sobjectsreceiver
+status:
+  availableReplicas: 1
+  readyReplicas: 1
+  replicas: 1

--- a/tests/e2e-otel/k8sobjectsreceiver/otel-k8sobjectsreceiver.yaml
+++ b/tests/e2e-otel/k8sobjectsreceiver/otel-k8sobjectsreceiver.yaml
@@ -1,0 +1,76 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: chainsaw-k8sobjectsreceiver
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: chainsaw-k8sobjectsreceiver
+  namespace: chainsaw-k8sobjectsreceiver
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: chainsaw-k8sobjectsreceiver-role
+rules:
+- apiGroups:
+  - ''
+  resources:
+  - events
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - get
+  - list
+  - watch
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: chainsaw-k8sobjectsreceiver-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: chainsaw-k8sobjectsreceiver-role
+subjects:
+  - kind: ServiceAccount
+    name: chainsaw-k8sobjectsreceiver
+    namespace: chainsaw-k8sobjectsreceiver
+
+---
+apiVersion: opentelemetry.io/v1alpha1
+kind: OpenTelemetryCollector
+metadata:
+  name: chainsaw-k8sobjectsreceiver
+  namespace: chainsaw-k8sobjectsreceiver
+spec:
+  mode: deployment
+  serviceAccount: chainsaw-k8sobjectsreceiver
+  serviceAccountName: chainsaw-k8sobjectsreceiver
+  config: |
+    receivers:
+      k8sobjects:
+        objects:
+          - name: pods
+            mode: pull
+          - name: events
+            mode: watch
+    exporters:
+      debug:
+        verbosity: detailed
+    service:
+      pipelines:
+        logs:
+          receivers: [k8sobjects]
+          exporters: [debug]

--- a/tests/e2e-otel/kubeletstatsreceiver/chainsaw-test.yaml
+++ b/tests/e2e-otel/kubeletstatsreceiver/chainsaw-test.yaml
@@ -1,0 +1,21 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: kubeletstatsreceiver
+spec:
+  steps:
+  - name: Create OTEL collector with kubeletstats receiver
+    try:
+    - apply:
+        file: otel-kubeletstatsreceiver.yaml
+    - assert:
+        file: otel-kubeletstatsreceiver-assert.yaml
+  - name: Wait for the metrics to be collected
+    try:
+    - sleep:
+        duration: 60s
+  - name: Check some of the metrics in the OTEl collector
+    try:
+    - script:
+        timeout: 5m
+        content: ./check_logs.sh 

--- a/tests/e2e-otel/kubeletstatsreceiver/check_logs.sh
+++ b/tests/e2e-otel/kubeletstatsreceiver/check_logs.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# This script checks the OpenTelemetry collector pod for the presence of Logs.
+
+# Define the label selector
+LABEL_SELECTOR="app.kubernetes.io/component=opentelemetry-collector"
+NAMESPACE=chainsaw-kubeletstatsreceiver
+
+# Define the search strings
+SEARCH_STRING1='k8s.pod.uid'
+SEARCH_STRING2='k8s.pod.name'
+SEARCH_STRING3='k8s.namespace.name'
+SEARCH_STRING4='k8s.container.name'
+
+# Get the list of pods with the specified label
+PODS=($(kubectl -n $NAMESPACE get pods -l $LABEL_SELECTOR -o jsonpath='{.items[*].metadata.name}'))
+
+# Initialize flags to track if strings are found
+FOUND1=false
+FOUND2=false
+FOUND3=false
+FOUND4=false
+
+# Loop through each pod and search for the strings in the logs
+for POD in "${PODS[@]}"; do
+    # Search for the first string
+    if ! $FOUND1 && kubectl -n $NAMESPACE --tail=200 logs $POD | grep -q -- "$SEARCH_STRING1"; then
+        echo "\"$SEARCH_STRING1\" found in $POD"
+        FOUND1=true
+    fi
+    # Search for the second string
+    if ! $FOUND2 && kubectl -n $NAMESPACE --tail=200 logs $POD | grep -q -- "$SEARCH_STRING2"; then
+        echo "\"$SEARCH_STRING2\" found in $POD"
+        FOUND2=true
+    fi
+    # Search for the third string
+    if ! $FOUND3 && kubectl -n $NAMESPACE --tail=200 logs $POD | grep -q -- "$SEARCH_STRING3"; then
+        echo "\"$SEARCH_STRING3\" found in $POD"
+        FOUND3=true
+    fi
+    # Search for the fourth string
+    if ! $FOUND4 && kubectl -n $NAMESPACE --tail=200 logs $POD | grep -q -- "$SEARCH_STRING4"; then
+        echo "\"$SEARCH_STRING4\" found in $POD"
+        FOUND4=true
+    fi
+done
+
+# Check if any of the strings was not found
+if ! $FOUND1 || ! $FOUND2 || ! $FOUND3 || ! $FOUND4; then
+    echo "No Node metrics found in OpenTelemetry collector"
+    exit 1
+else
+    echo "Found all the Node metrics in OpenTelemetry collector."
+fi

--- a/tests/e2e-otel/kubeletstatsreceiver/otel-kubeletstatsreceiver-assert.yaml
+++ b/tests/e2e-otel/kubeletstatsreceiver/otel-kubeletstatsreceiver-assert.yaml
@@ -1,0 +1,64 @@
+apiVersion: project.openshift.io/v1
+kind: Project
+metadata:
+  name: chainsaw-kubeletstatsreceiver
+status:
+  phase: Active
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: chainsaw-kubeletstatsreceiver
+  namespace: chainsaw-kubeletstatsreceiver
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: chainsaw-kubeletstatsreceiver-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes/stats
+  verbs:
+  - get
+  - watch
+  - list
+- apiGroups:
+  - ""
+  resources:
+  - nodes/proxy
+  verbs:
+  - get
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: chainsaw-kubeletstatsreceiver-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: chainsaw-kubeletstatsreceiver-role
+subjects:
+- kind: ServiceAccount
+  name: chainsaw-kubeletstatsreceiver
+  namespace: chainsaw-kubeletstatsreceiver
+
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: chainsaw-kubeletstatsreceiver-collector
+  namespace: chainsaw-kubeletstatsreceiver
+spec:
+  updateStrategy:
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+    type: RollingUpdate
+status:
+  numberMisscheduled: 0
+  (desiredNumberScheduled == numberReady): true

--- a/tests/e2e-otel/kubeletstatsreceiver/otel-kubeletstatsreceiver.yaml
+++ b/tests/e2e-otel/kubeletstatsreceiver/otel-kubeletstatsreceiver.yaml
@@ -1,0 +1,73 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: chainsaw-kubeletstatsreceiver
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: chainsaw-kubeletstatsreceiver
+  namespace: chainsaw-kubeletstatsreceiver
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: chainsaw-kubeletstatsreceiver-role
+rules:
+  - apiGroups: ['']
+    resources: ['nodes/stats']
+    verbs: ['get', 'watch', 'list']
+  - apiGroups: [""]
+    resources: ["nodes/proxy"]
+    verbs: ["get"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: chainsaw-kubeletstatsreceiver-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: chainsaw-kubeletstatsreceiver-role
+subjects:
+  - kind: ServiceAccount
+    name: chainsaw-kubeletstatsreceiver
+    namespace: chainsaw-kubeletstatsreceiver
+
+---
+apiVersion: opentelemetry.io/v1alpha1
+kind: OpenTelemetryCollector
+metadata:
+  name: chainsaw-kubeletstatsreceiver
+  namespace: chainsaw-kubeletstatsreceiver
+spec:
+  mode: daemonset
+  serviceAccount: chainsaw-kubeletstatsreceiver
+  serviceAccountName: chainsaw-kubeletstatsreceiver
+  env:
+  - name: K8S_NODE_NAME
+    valueFrom:
+      fieldRef:
+        fieldPath: spec.nodeName
+  config: |
+    receivers:
+      kubeletstats:
+        collection_interval: 20s
+        auth_type: "serviceAccount"
+        endpoint: "https://${env:K8S_NODE_NAME}:10250"
+        insecure_skip_verify: true
+    exporters:
+      debug:
+        verbosity: detailed
+    service:
+      pipelines:
+        metrics:
+          receivers: [kubeletstats]
+          exporters: [debug]
+  tolerations:
+  - key: node-role.kubernetes.io/master
+    operator: Exists
+    effect: NoSchedule

--- a/tests/e2e-otel/loadbalancingexporter/chainsaw-test.yaml
+++ b/tests/e2e-otel/loadbalancingexporter/chainsaw-test.yaml
@@ -1,0 +1,34 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: loadbalancingexporter
+spec:
+  namespace: chainsaw-lb
+  steps:
+  - name: Create OTEL collector which acts as backend with 5 replicas, we will use the headless service for LB
+    try:
+    - apply:
+        file: otel-loadbalancingexporter-backends.yaml
+    - assert:
+        file: otel-loadbalancingexporter-backends-assert.yaml
+  - name: Create OTEL collector with loadbalancingexporter which uses k8s resolver to discover the backend IPs from the backend collector headless service
+    try:
+    - apply:
+        file: otel-loadbalancingexporter-lb.yaml
+    - assert:
+        file: otel-loadbalancingexporter-lb-assert.yaml
+  - name: Generate traces with service names telemetrygen-http-blue, telemetrygen-http-red, telemetrygen-http-green and send it to the LB collector.
+    try:
+    - apply:
+        file: generate-traces.yaml
+    - assert:
+        file: generate-traces-assert.yaml
+  - name: Wait for the traces to be collected
+    try:
+    - sleep:
+        duration: 5s
+  - name: Check traces in the backend collector pods. Traces for a service name should be present in only one backend pod.
+    try:
+    - script:
+        timeout: 5m
+        content: ./check_logs.sh 

--- a/tests/e2e-otel/loadbalancingexporter/check_logs.sh
+++ b/tests/e2e-otel/loadbalancingexporter/check_logs.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# Define the required service names
+required_service_names=("telemetrygen-http-blue" "telemetrygen-http-red" "telemetrygen-http-green")
+
+# Get the list of pods with the specified label
+pods=$(oc get pods -n chainsaw-lb -l app.kubernetes.io/name=chainsaw-lb-backends-collector -o jsonpath="{.items[*].metadata.name}")
+
+# Initialize an empty string to hold all service names from all pods
+all_service_names=""
+
+for pod in $pods; do
+  echo "Checking pod: $pod"
+
+  # Get the logs of the pod
+  logs=$(oc -n chainsaw-lb logs $pod)
+
+  # Extract the unique service.name values from the logs
+  service_names=$(echo "$logs" | grep -i "service.name" | awk -F': ' '{print $2}' | sort | uniq)
+
+  # Check if a service.name is found in a pod, it should not be present in another pod
+  for service_name in $service_names; do
+    if echo "$all_service_names" | grep -q "$service_name"; then
+      echo "Error: Service name $service_name found in more than one pod"
+      exit 1
+    else
+      all_service_names+="$service_name "
+      echo "Service.name $service_name found in pod $pod"
+    fi
+  done
+done
+
+# Check if all required service names are present in all_service_names
+for required_service_name in "${required_service_names[@]}"; do
+  if ! echo "$all_service_names" | grep -q "$required_service_name"; then
+    echo "Error: Required service name $required_service_name is missing in the logs"
+    exit 1
+  fi
+done
+
+echo "All required service names are present in the logs of all pods"

--- a/tests/e2e-otel/loadbalancingexporter/generate-traces-assert.yaml
+++ b/tests/e2e-otel/loadbalancingexporter/generate-traces-assert.yaml
@@ -1,0 +1,25 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: generate-traces-http-blue
+  namespace: chainsaw-lb
+status:
+  succeeded: 1
+
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: generate-traces-http-green
+  namespace: chainsaw-lb
+status:
+  succeeded: 1
+
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: generate-traces-http-red
+  namespace: chainsaw-lb
+status:
+  succeeded: 1

--- a/tests/e2e-otel/loadbalancingexporter/generate-traces.yaml
+++ b/tests/e2e-otel/loadbalancingexporter/generate-traces.yaml
@@ -1,0 +1,61 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: generate-traces-http-blue
+spec:
+  template:
+    spec:
+      containers:
+      - name: telemetrygen-blue
+        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
+        args:
+        - traces
+        - --otlp-endpoint=chainsaw-lb-collector:4318
+        - --traces=5
+        - --otlp-http
+        - --otlp-insecure=true
+        - --service=telemetrygen-http-blue
+        - --otlp-attributes=protocol="otlp-http-blue"
+      restartPolicy: Never
+
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: generate-traces-http-green
+spec:
+  template:
+    spec:
+      containers:
+      - name: telemetrygen-green
+        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
+        args:
+        - traces
+        - --otlp-endpoint=chainsaw-lb-collector:4318
+        - --traces=5
+        - --otlp-http
+        - --otlp-insecure=true
+        - --service=telemetrygen-http-green
+        - --otlp-attributes=protocol="otlp-http-green"
+      restartPolicy: Never
+
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: generate-traces-http-red
+spec:
+  template:
+    spec:
+      containers:
+      - name: telemetrygen-red
+        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
+        args:
+        - traces
+        - --otlp-endpoint=chainsaw-lb-collector:4318
+        - --traces=5
+        - --otlp-http
+        - --otlp-insecure=true
+        - --service=telemetrygen-http-red
+        - --otlp-attributes=protocol="otlp-http-red"
+      restartPolicy: Never

--- a/tests/e2e-otel/loadbalancingexporter/otel-loadbalancingexporter-backends-assert.yaml
+++ b/tests/e2e-otel/loadbalancingexporter/otel-loadbalancingexporter-backends-assert.yaml
@@ -1,0 +1,28 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: chainsaw-lb-backends-collector
+  namespace: chainsaw-lb
+status:
+  availableReplicas: 5
+  readyReplicas: 5
+  replicas: 5
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: chainsaw-lb-backends-collector-headless
+  namespace: chainsaw-lb
+spec:
+  ports:
+  - appProtocol: grpc
+    name: otlp-grpc
+    port: 4317
+    protocol: TCP
+    targetPort: 4317
+  selector:
+    app.kubernetes.io/component: opentelemetry-collector
+    app.kubernetes.io/instance: chainsaw-lb.chainsaw-lb-backends
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/part-of: opentelemetry

--- a/tests/e2e-otel/loadbalancingexporter/otel-loadbalancingexporter-backends.yaml
+++ b/tests/e2e-otel/loadbalancingexporter/otel-loadbalancingexporter-backends.yaml
@@ -1,0 +1,25 @@
+apiVersion: opentelemetry.io/v1alpha1
+kind: OpenTelemetryCollector
+metadata:
+  name: chainsaw-lb-backends
+  namespace: chainsaw-lb
+spec:
+  replicas: 5
+  config: |
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+
+    processors:
+
+    exporters:
+      debug:
+        verbosity: detailed
+
+    service:
+      pipelines:
+        traces:
+          receivers: [otlp]
+          processors: []
+          exporters: [debug]

--- a/tests/e2e-otel/loadbalancingexporter/otel-loadbalancingexporter-lb-assert.yaml
+++ b/tests/e2e-otel/loadbalancingexporter/otel-loadbalancingexporter-lb-assert.yaml
@@ -1,0 +1,66 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: chainsaw-lb
+  namespace: chainsaw-lb
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: chainsaw-lb-role
+  namespace: chainsaw-lb
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  verbs:
+  - list
+  - watch
+  - get
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: chainsaw-lb-rolebinding
+  namespace: chainsaw-lb
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: chainsaw-lb-role
+subjects:
+- kind: ServiceAccount
+  name: chainsaw-lb
+  namespace: chainsaw-lb
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: chainsaw-lb-collector
+  namespace: chainsaw-lb
+status:
+  availableReplicas: 1
+  readyReplicas: 1
+  replicas: 1
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: chainsaw-lb-collector
+  namespace: chainsaw-lb
+spec:
+  ports:
+  - appProtocol: http
+    name: otlp-http
+    port: 4318
+    protocol: TCP
+    targetPort: 4318
+  selector:
+    app.kubernetes.io/component: opentelemetry-collector
+    app.kubernetes.io/instance: chainsaw-lb.chainsaw-lb
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/part-of: opentelemetry

--- a/tests/e2e-otel/loadbalancingexporter/otel-loadbalancingexporter-lb.yaml
+++ b/tests/e2e-otel/loadbalancingexporter/otel-loadbalancingexporter-lb.yaml
@@ -1,0 +1,70 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: chainsaw-lb
+  namespace: chainsaw-lb
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: chainsaw-lb-role
+  namespace: chainsaw-lb
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  verbs:
+  - list
+  - watch
+  - get
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: chainsaw-lb-rolebinding
+  namespace: chainsaw-lb
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: chainsaw-lb-role
+subjects:
+- kind: ServiceAccount
+  name: chainsaw-lb
+  namespace: chainsaw-lb
+
+---
+apiVersion: opentelemetry.io/v1alpha1
+kind: OpenTelemetryCollector
+metadata:
+  name: chainsaw-lb
+  namespace: chainsaw-lb
+spec:
+  serviceAccount: chainsaw-lb
+  config: |
+    receivers:
+      otlp:
+        protocols:
+          http:
+
+    processors:
+
+    exporters:
+      loadbalancing:
+        protocol:
+          otlp:
+            tls:
+              insecure: true
+        resolver:
+          k8s:
+            service: chainsaw-lb-backends-collector-headless.chainsaw-lb
+        routing_key: "service"
+
+    service:
+      pipelines:
+        traces:
+          receivers: [otlp]
+          processors: []
+          exporters: [loadbalancing]

--- a/tests/e2e-otel/oidcauthextension/chainsaw-test.yaml
+++ b/tests/e2e-otel/oidcauthextension/chainsaw-test.yaml
@@ -1,0 +1,53 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: oidcauthextension
+spec:
+  # Need to use static namespace for oidc authentication
+  namespace: chainsaw-oidcauthextension
+  steps:
+  - name: Install Hydra for OIDC
+    try:
+    - apply:
+        file: install-hydra.yaml
+    - assert:
+        file: install-hydra-assert.yaml
+  - name: Create OAuth2 client in Hydra
+    try:
+    - apply:
+        file: setup-hydra.yaml
+    - assert:
+        file: setup-hydra-assert.yaml
+  - name: Generate certs and create configmap required by OTEL collectors
+    try:
+    - script:
+        timeout: 5m
+        content: ./generate_certs.sh
+  - name: Create OTEL collector instance with OIDC auth extension in OTLP receiver
+    try:
+    - apply:
+        file: install-otel-oidc-server.yaml
+    - assert:
+        file: install-otel-oidc-server-assert.yaml
+  - name: Create OTEL collector instance with oauth2client auth extension in OTLP exporter
+    try:
+    - apply:
+        file: install-otel-oidc-client.yaml
+    - assert:
+        file: install-otel-oidc-client-assert.yaml
+  - name: Generate traces to ingest in client OTEL collector
+    try:
+    - apply:
+        file: generate-traces.yaml
+    - assert:
+        file: generate-traces-assert.yaml
+  - name: Wait for the traces to be collected by OTEL collector
+    try:
+    - sleep:
+        duration: 60s
+  - name: Check traces in the OTEL server collector
+    try:
+    - script:
+        timeout: 5m
+        content: ./check_logs.sh
+

--- a/tests/e2e-otel/oidcauthextension/check_logs.sh
+++ b/tests/e2e-otel/oidcauthextension/check_logs.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# This script checks the OpenTelemetry collector pod for the presence of Logs.
+
+# Define the label selector
+LABEL_SELECTOR="app.kubernetes.io/name=chainsaw-oidc-server-collector"
+NAMESPACE=chainsaw-oidcauthextension
+
+# Define the search strings
+SEARCH_STRING1='Name           : lets-go'
+SEARCH_STRING2='Name           : okey-dokey'
+SEARCH_STRING3='Trace ID'
+SEARCH_STRING4='Parent ID'
+
+# Initialize flags to track if strings are found
+FOUND1=false
+FOUND2=false
+FOUND3=false
+FOUND4=false
+
+# Loop until all strings are found
+while ! $FOUND1 || ! $FOUND2 || ! $FOUND3 || ! $FOUND4; do
+    # Get the list of pods with the specified label
+    PODS=($(kubectl -n $NAMESPACE get pods -l $LABEL_SELECTOR -o jsonpath='{.items[*].metadata.name}'))
+    
+    # Loop through each pod and search for the strings in the logs
+    for POD in "${PODS[@]}"; do
+        # Search for the first string
+        if ! $FOUND1 && kubectl -n $NAMESPACE --tail=200 logs $POD | grep -q -- "$SEARCH_STRING1"; then
+            echo "\"$SEARCH_STRING1\" found in $POD"
+            FOUND1=true
+        fi
+        # Search for the second string
+        if ! $FOUND2 && kubectl -n $NAMESPACE --tail=200 logs $POD | grep -q -- "$SEARCH_STRING2"; then
+            echo "\"$SEARCH_STRING2\" found in $POD"
+            FOUND2=true
+        fi
+        # Search for the third string
+        if ! $FOUND3 && kubectl -n $NAMESPACE --tail=200 logs $POD | grep -q -- "$SEARCH_STRING3"; then
+            echo "\"$SEARCH_STRING3\" found in $POD"
+            FOUND3=true
+        fi
+        # Search for the fourth string
+        if ! $FOUND4 && kubectl -n $NAMESPACE --tail=200 logs $POD | grep -q -- "$SEARCH_STRING4"; then
+            echo "\"$SEARCH_STRING4\" found in $POD"
+            FOUND4=true
+        fi
+    done
+done
+
+echo "Found all the Traces in OpenTelemetry collector."

--- a/tests/e2e-otel/oidcauthextension/generate-traces-assert.yaml
+++ b/tests/e2e-otel/oidcauthextension/generate-traces-assert.yaml
@@ -1,0 +1,6 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: generate-traces-grpc
+status:
+  succeeded: 1

--- a/tests/e2e-otel/oidcauthextension/generate-traces.yaml
+++ b/tests/e2e-otel/oidcauthextension/generate-traces.yaml
@@ -1,0 +1,18 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: generate-traces-grpc
+spec:
+  template:
+    spec:
+      containers:
+      - name: telemetrygen
+        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
+        args:
+        - traces
+        - --otlp-endpoint=chainsaw-oidc-client-collector:4317
+        - --traces=100
+        - --otlp-insecure=true
+        - --service=telemetrygen-grpc
+        - --otlp-attributes=protocol="grpc"
+      restartPolicy: Never

--- a/tests/e2e-otel/oidcauthextension/generate_certs.sh
+++ b/tests/e2e-otel/oidcauthextension/generate_certs.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+# Create a directory to store certificates
+CERT_DIR="/tmp/chainsaw-certs"
+rm -rf "$CERT_DIR"
+mkdir -p "$CERT_DIR"
+
+# Get hostname domain from OpenShift
+hostname_domain="*.apps.$(oc get dns cluster -o jsonpath='{.spec.baseDomain}')"
+
+# Set certificate information
+CERT_SUBJECT="/C=US/ST=California/L=San Francisco/O=My Organization/CN=opentelemetry"
+
+# Create a temporary OpenSSL configuration file for SANs
+openssl_config="$CERT_DIR/openssl.cnf"
+cat <<EOF > "$openssl_config"
+[ req ]
+default_bits       = 2048
+distinguished_name = req_distinguished_name
+req_extensions     = v3_req
+
+[ req_distinguished_name ]
+countryName                = Country Name (2 letter code)
+countryName_default        = US
+stateOrProvinceName        = State or Province Name (full name)
+stateOrProvinceName_default= California
+localityName               = Locality Name (eg, city)
+localityName_default       = San Francisco
+organizationName           = Organization Name (eg, company)
+organizationName_default   = My Organization
+commonName                 = Common Name (eg, your name or your server's hostname)
+commonName_max             = 64
+
+[ v3_req ]
+basicConstraints = CA:FALSE
+keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+subjectAltName = @alt_names
+
+[ alt_names ]
+DNS.1 = opentelemetry
+DNS.2 = $hostname_domain
+DNS.3 = chainsaw-oidc-server-collector
+EOF
+
+# Generate private key for the server
+openssl genpkey -algorithm RSA -out "$CERT_DIR/server.key"
+
+# Create CSR for the server with SANs
+openssl req -new -key "$CERT_DIR/server.key" -out "$CERT_DIR/server.csr" -subj "$CERT_SUBJECT" -config "$openssl_config"
+
+# Generate self-signed certificate for the server with SANs
+openssl x509 -req -days 365 -in "$CERT_DIR/server.csr" -signkey "$CERT_DIR/server.key" -out "$CERT_DIR/server.crt" -extensions v3_req -extfile "$openssl_config"
+
+# Generate a CA certificate (self-signed)
+openssl req -new -x509 -days 365 -key "$CERT_DIR/server.key" -out "$CERT_DIR/ca.crt" -subj "$CERT_SUBJECT"
+
+echo "Certificates generated successfully in $CERT_DIR directory."
+
+# Delete any existing ConfigMaps
+kubectl delete configmap -n chainsaw-oidcauthextension chainsaw-certs
+
+# Create a Kubernetes ConfigMap for the server certificate, private key, and CA certificate in chainsaw-multi-cluster-send namespace
+kubectl create configmap chainsaw-certs -n chainsaw-oidcauthextension \
+  --from-file=server.crt="$CERT_DIR/server.crt" \
+  --from-file=server.key="$CERT_DIR/server.key" \
+  --from-file=ca.crt="$CERT_DIR/ca.crt"
+
+echo "ConfigMaps created successfully."
+

--- a/tests/e2e-otel/oidcauthextension/install-hydra-assert.yaml
+++ b/tests/e2e-otel/oidcauthextension/install-hydra-assert.yaml
@@ -1,0 +1,26 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hydra
+status:
+  availableReplicas: 1
+  readyReplicas: 1
+  replicas: 1
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: hydra
+spec:
+  ports:
+  - name: public
+    port: 4444
+    protocol: TCP
+    targetPort: public
+  - name: internal
+    port: 4445
+    protocol: TCP
+    targetPort: internal
+  selector:
+    app: hydra

--- a/tests/e2e-otel/oidcauthextension/install-hydra.yaml
+++ b/tests/e2e-otel/oidcauthextension/install-hydra.yaml
@@ -1,0 +1,46 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hydra
+spec:
+  selector:
+    matchLabels:
+      app: hydra
+  template:
+    metadata:
+      labels:
+        app: hydra
+    spec:
+      containers:
+      - name: hydra
+        image: docker.io/oryd/hydra:v2.2.0
+        command: ["hydra", "serve", "all", "--dev", "--sqa-opt-out"]
+        env:
+        - name: DSN
+          value: memory
+        - name: SECRETS_SYSTEM
+          value: saf325iouepdsg8574nb39afdu
+        - name: URLS_SELF_ISSUER
+          value: http://hydra:4444
+        - name: STRATEGIES_ACCESS_TOKEN
+          value: jwt
+        ports:
+        - containerPort: 4444
+          name: public
+        - containerPort: 4445
+          name: internal
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: hydra
+spec:
+  selector:
+    app: hydra
+  ports:
+  - name: public
+    port: 4444
+    targetPort: public
+  - name: internal
+    port: 4445
+    targetPort: internal

--- a/tests/e2e-otel/oidcauthextension/install-otel-oidc-client-assert.yaml
+++ b/tests/e2e-otel/oidcauthextension/install-otel-oidc-client-assert.yaml
@@ -1,0 +1,31 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: chainsaw-oidc-client-collector
+status:
+  availableReplicas: 1
+  readyReplicas: 1
+  replicas: 1
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: chainsaw-oidc-client-collector
+spec:
+  ports:
+  - appProtocol: grpc
+    name: otlp-grpc
+    port: 4317
+    protocol: TCP
+    targetPort: 4317
+  - appProtocol: http
+    name: otlp-http
+    port: 4318
+    protocol: TCP
+    targetPort: 4318
+  selector:
+    app.kubernetes.io/component: opentelemetry-collector
+    app.kubernetes.io/instance: chainsaw-oidcauthextension.chainsaw-oidc-client
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/part-of: opentelemetry

--- a/tests/e2e-otel/oidcauthextension/install-otel-oidc-client.yaml
+++ b/tests/e2e-otel/oidcauthextension/install-otel-oidc-client.yaml
@@ -1,0 +1,46 @@
+apiVersion: opentelemetry.io/v1alpha1
+kind: OpenTelemetryCollector
+metadata:
+  name: chainsaw-oidc-client
+spec:
+  mode: deployment
+  volumes:
+    - name: chainsaw-certs
+      configMap: 
+        name: chainsaw-certs
+  volumeMounts:
+    - name: chainsaw-certs
+      mountPath: /certs
+  config: |
+    extensions:
+      oauth2client:
+        client_id: tenant1-oidc-client
+        client_secret: ZXhhbXBsZS1hcHAtc2VjcmV0
+        endpoint_params:
+          audience: tenant1-oidc-client
+        token_url: http://hydra:4444/oauth2/token
+
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+          http:
+
+    processors:
+
+    exporters:
+      otlp:
+        endpoint: chainsaw-oidc-server-collector:4317
+        tls:
+          insecure: false
+          ca_file: /certs/ca.crt
+        auth:
+          authenticator: oauth2client
+
+    service:
+      extensions: [oauth2client]
+      pipelines:
+        traces:
+          receivers: [otlp]
+          processors: []
+          exporters: [otlp]

--- a/tests/e2e-otel/oidcauthextension/install-otel-oidc-server-assert.yaml
+++ b/tests/e2e-otel/oidcauthextension/install-otel-oidc-server-assert.yaml
@@ -1,0 +1,26 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: chainsaw-oidc-server-collector
+status:
+  availableReplicas: 1
+  readyReplicas: 1
+  replicas: 1
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: chainsaw-oidc-server-collector
+spec:
+  ports:
+  - appProtocol: grpc
+    name: otlp-grpc
+    port: 4317
+    protocol: TCP
+    targetPort: 4317
+  selector:
+    app.kubernetes.io/component: opentelemetry-collector
+    app.kubernetes.io/instance: chainsaw-oidcauthextension.chainsaw-oidc-server
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/part-of: opentelemetry

--- a/tests/e2e-otel/oidcauthextension/install-otel-oidc-server.yaml
+++ b/tests/e2e-otel/oidcauthextension/install-otel-oidc-server.yaml
@@ -1,0 +1,42 @@
+apiVersion: opentelemetry.io/v1alpha1
+kind: OpenTelemetryCollector
+metadata:
+  name: chainsaw-oidc-server
+spec:
+  mode: deployment
+  volumeMounts:
+  - mountPath: /certs
+    name: chainsaw-certs
+  volumes:
+  - configMap:
+      name: chainsaw-certs
+    name: chainsaw-certs
+  config: |
+    extensions:
+      oidc:
+        issuer_url: http://hydra:4444
+        audience: tenant1-oidc-client
+
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+            tls:
+              cert_file: /certs/server.crt
+              key_file: /certs/server.key
+            auth:
+              authenticator: oidc
+
+    processors:
+
+    exporters:
+      debug:
+        verbosity: detailed
+
+    service:
+      extensions: [oidc]
+      pipelines:
+        traces:
+          receivers: [otlp]
+          processors: []
+          exporters: [debug]

--- a/tests/e2e-otel/oidcauthextension/setup-hydra-assert.yaml
+++ b/tests/e2e-otel/oidcauthextension/setup-hydra-assert.yaml
@@ -1,0 +1,6 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: setup-hydra
+status:
+  succeeded: 1

--- a/tests/e2e-otel/oidcauthextension/setup-hydra.yaml
+++ b/tests/e2e-otel/oidcauthextension/setup-hydra.yaml
@@ -1,0 +1,20 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: setup-hydra
+spec:
+  template:
+    spec:
+      containers:
+      - name: setup-hydra
+        image: ghcr.io/grafana/tempo-operator/test-utils:main
+        command: ["/bin/bash", "-eux", "-c"]
+        args:
+        - |
+          # create OAuth2 client
+          client_id=tenant1-oidc-client
+          client_secret=ZXhhbXBsZS1hcHAtc2VjcmV0 # notsecret
+          curl -v \
+            --data '{"audience": ["'$client_id'"], "client_id": "'$client_id'", "client_secret": "'$client_secret'", "grant_types": ["client_credentials"], "token_endpoint_auth_method": "client_secret_basic"}' \
+            http://hydra:4445/admin/clients
+      restartPolicy: Never

--- a/tests/e2e-otel/otlpjsonfilereceiver/chainsaw-test.yaml
+++ b/tests/e2e-otel/otlpjsonfilereceiver/chainsaw-test.yaml
@@ -1,0 +1,42 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: otlpjsonfilereceiver
+spec:
+  steps:
+  - name: Create Tempo Monolithic instance
+    try:
+    - apply:
+        file: install-tempo.yaml
+    - assert:
+        file: install-tempo-assert.yaml
+  - name: Create a PVC to be used by OTEL collectors.
+    try:
+    - apply:
+        file: create-pvc.yaml
+    - assert:
+        file: create-pvc-assert.yaml
+  - name: Creat a OTEL collector with fileexporter which will export Trace data in OTLP format to a file
+    try:
+    - apply:
+        file: fileexporter-otel-collector.yaml
+    - assert:
+        file: fileexporter-otel-collector-assert.yaml
+  - name: Create a OTEL collector with otlpjsonfilereceiver to receive OTLP telemetry data from a file exported by filereceiver
+    try:
+    - apply:
+        file: otlpjsonfilereceiver-otel-collector.yaml
+    - assert:
+        file: otlpjsonfilereceiver-otel-collector-assert.yaml
+  - name: Generate traces and send it to the OTEL collector with fileexporter
+    try:
+    - apply:
+        file: generate-traces.yaml
+    - assert:
+        file: generate-traces-assert.yaml
+  - name: Verify traces
+    try:
+    - apply:
+        file: verify-traces.yaml
+    - assert:
+        file: verify-traces-assert.yaml

--- a/tests/e2e-otel/otlpjsonfilereceiver/create-pvc-assert.yaml
+++ b/tests/e2e-otel/otlpjsonfilereceiver/create-pvc-assert.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: otlp-data
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Gi
+  volumeMode: Filesystem

--- a/tests/e2e-otel/otlpjsonfilereceiver/create-pvc.yaml
+++ b/tests/e2e-otel/otlpjsonfilereceiver/create-pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    app.kubernetes.io/name: otel
+  name: otlp-data
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Gi

--- a/tests/e2e-otel/otlpjsonfilereceiver/fileexporter-otel-collector-assert.yaml
+++ b/tests/e2e-otel/otlpjsonfilereceiver/fileexporter-otel-collector-assert.yaml
@@ -1,0 +1,26 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: fileexporter-collector
+status:
+  availableReplicas: 1
+  readyReplicas: 1
+  replicas: 1
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: fileexporter-collector
+spec:
+  ports:
+  - appProtocol: grpc
+    name: otlp-grpc
+    port: 4317
+    protocol: TCP
+    targetPort: 4317
+  selector:
+    app.kubernetes.io/component: opentelemetry-collector
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/part-of: opentelemetry
+  type: ClusterIP

--- a/tests/e2e-otel/otlpjsonfilereceiver/fileexporter-otel-collector.yaml
+++ b/tests/e2e-otel/otlpjsonfilereceiver/fileexporter-otel-collector.yaml
@@ -1,0 +1,31 @@
+apiVersion: opentelemetry.io/v1alpha1
+kind: OpenTelemetryCollector
+metadata:
+  name: fileexporter
+spec:
+  config: |
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+
+    processors:
+
+    exporters:
+      debug:
+      file:
+        path: /telemetry-data/telemetrygen-traces.json
+
+    service:
+      pipelines:
+        traces:
+          receivers: [otlp]
+          processors: []
+          exporters: [debug,file]
+  volumes:
+    - name: file
+      persistentVolumeClaim:
+        claimName: otlp-data
+  volumeMounts: 
+    - name: file
+      mountPath: /telemetry-data

--- a/tests/e2e-otel/otlpjsonfilereceiver/generate-traces-assert.yaml
+++ b/tests/e2e-otel/otlpjsonfilereceiver/generate-traces-assert.yaml
@@ -1,0 +1,6 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: generate-traces
+status:
+  succeeded: 1

--- a/tests/e2e-otel/otlpjsonfilereceiver/generate-traces.yaml
+++ b/tests/e2e-otel/otlpjsonfilereceiver/generate-traces.yaml
@@ -1,0 +1,18 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: generate-traces
+spec:
+  template:
+    spec:
+      containers:
+      - name: telemetrygen
+        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
+        args:
+        - traces
+        - --otlp-endpoint=fileexporter-collector:4317
+        - --otlp-insecure=true
+        - --traces=5
+        - --service=from-otlp-jsonfile
+      restartPolicy: Never
+  backoffLimit: 4

--- a/tests/e2e-otel/otlpjsonfilereceiver/install-tempo-assert.yaml
+++ b/tests/e2e-otel/otlpjsonfilereceiver/install-tempo-assert.yaml
@@ -1,0 +1,8 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: tempo-jsonrecv
+status:
+  availableReplicas: 1
+  readyReplicas: 1
+  replicas: 1

--- a/tests/e2e-otel/otlpjsonfilereceiver/install-tempo.yaml
+++ b/tests/e2e-otel/otlpjsonfilereceiver/install-tempo.yaml
@@ -1,0 +1,9 @@
+apiVersion: tempo.grafana.com/v1alpha1
+kind: TempoMonolithic
+metadata:
+  name: jsonrecv
+spec:
+  jaegerui:
+    enabled: true
+    route:
+      enabled: true

--- a/tests/e2e-otel/otlpjsonfilereceiver/otlpjsonfilereceiver-otel-collector-assert.yaml
+++ b/tests/e2e-otel/otlpjsonfilereceiver/otlpjsonfilereceiver-otel-collector-assert.yaml
@@ -1,0 +1,25 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: otlpjsonfile-collector
+status:
+  availableReplicas: 1
+  readyReplicas: 1
+  replicas: 1
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: otlpjsonfile-collector-monitoring
+spec:
+  ports:
+  - name: monitoring
+    port: 8888
+    protocol: TCP
+    targetPort: 8888
+  selector:
+    app.kubernetes.io/component: opentelemetry-collector
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/part-of: opentelemetry
+  type: ClusterIP

--- a/tests/e2e-otel/otlpjsonfilereceiver/otlpjsonfilereceiver-otel-collector.yaml
+++ b/tests/e2e-otel/otlpjsonfilereceiver/otlpjsonfilereceiver-otel-collector.yaml
@@ -1,0 +1,33 @@
+apiVersion: opentelemetry.io/v1alpha1
+kind: OpenTelemetryCollector
+metadata:
+  name: otlpjsonfile
+spec:
+  config: |
+    receivers:
+      otlpjsonfile:
+        include:
+          - "/telemetry-data/*.json"
+
+    processors:
+
+    exporters:
+      debug:
+      otlp:
+        endpoint: tempo-jsonrecv:4317
+        tls:
+          insecure: true
+
+    service:
+      pipelines:
+        traces:
+          receivers: [otlpjsonfile]
+          processors: []
+          exporters: [debug,otlp]
+  volumes:
+    - name: file
+      persistentVolumeClaim:
+        claimName: otlp-data
+  volumeMounts: 
+    - name: file
+      mountPath: /telemetry-data

--- a/tests/e2e-otel/otlpjsonfilereceiver/verify-traces-assert.yaml
+++ b/tests/e2e-otel/otlpjsonfilereceiver/verify-traces-assert.yaml
@@ -1,0 +1,6 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: verify-traces
+status:
+  succeeded: 1

--- a/tests/e2e-otel/otlpjsonfilereceiver/verify-traces.yaml
+++ b/tests/e2e-otel/otlpjsonfilereceiver/verify-traces.yaml
@@ -1,0 +1,23 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: verify-traces
+spec:
+  template:
+    spec:
+      containers:
+      - name: verify-traces
+        image: ghcr.io/grafana/tempo-operator/test-utils:main
+        command:
+        - /bin/bash
+        - -eux
+        - -c
+        args:
+        - |
+          curl -v -G http://tempo-jsonrecv-jaegerui:16686/api/traces --data-urlencode "service=from-otlp-jsonfile" | tee /tmp/jaeger.out
+          num_traces=$(jq ".data | length" /tmp/jaeger.out)
+          if [[ "$num_traces" -ne 5 ]]; then
+            echo && echo "The Jaeger API returned $num_traces instead of 10 traces."
+            exit 1
+          fi
+      restartPolicy: Never

--- a/tests/e2e-otel/prometheusremotewriteexporter/README.md
+++ b/tests/e2e-otel/prometheusremotewriteexporter/README.md
@@ -1,0 +1,8 @@
+# Generate certs
+The example certs were generated with the following commands:
+
+openssl req -x509 -newkey rsa:4096 -sha256 -days 3650 -nodes -keyout ca.key -out ca.crt -subj '/CN=MyDemoCA'
+openssl req -x509 -newkey rsa:4096 -sha256 -days 3650 -nodes -keyout cert.key -out cert.crt -CA ca.crt -CAkey ca.key -subj "/CN=prometheus" -addext "subjectAltName=DNS:prometheus"
+
+oc create secret generic prometheus-ca --from-file=ca.crt -n NAMESPACE
+oc create secret tls prometheus-certs --cert=cert.crt --key=cert.key -n NAMESPACE

--- a/tests/e2e-otel/prometheusremotewriteexporter/chainsaw-test.yaml
+++ b/tests/e2e-otel/prometheusremotewriteexporter/chainsaw-test.yaml
@@ -1,0 +1,30 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: prometheusremotewriteexporter
+spec:
+  steps:
+  - name: Create a Prometheus deployment with remote write receiver enabled
+    try:
+    - apply:
+        file: deploy-prometheus.yaml
+    - assert:
+        file: deploy-prometheus-assert.yaml
+  - name: Create OTEL collector instance
+    try:
+    - apply:
+        file: otel-collector.yaml
+    - assert:
+        file: otel-collector-assert.yaml
+  - name: Generate and send metrics to the OTEL collector
+    try:
+    - apply:
+        file: generate-metrics.yaml
+    - assert:
+        file: generate-metrics-assert.yaml
+  - name: Verify metrics in the Prometheus instances
+    try:
+    - apply:
+        file: check-metrics.yaml
+    - assert:
+        file: check-metrics-assert.yaml

--- a/tests/e2e-otel/prometheusremotewriteexporter/check-metrics-assert.yaml
+++ b/tests/e2e-otel/prometheusremotewriteexporter/check-metrics-assert.yaml
@@ -1,0 +1,6 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: check-metrics
+status:
+  succeeded: 1

--- a/tests/e2e-otel/prometheusremotewriteexporter/check-metrics.yaml
+++ b/tests/e2e-otel/prometheusremotewriteexporter/check-metrics.yaml
@@ -1,0 +1,35 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: check-metrics
+spec:
+  template:
+    spec:
+      containers:
+      - name: check-metrics
+        image: ghcr.io/grafana/tempo-operator/test-utils:main
+        command:
+        - /bin/bash
+        - -eux
+        - -c
+        args:
+        - |
+          output=$(curl -s --cacert /etc/prometheus-ca/ca.crt \
+          --data-urlencode 'query=gen' \
+          https://prometheus:9090/api/v1/query)
+          if [[ "$output" == *'"__name__":"gen"'* && "$output" == *'"telemetrygen":"metrics"'* ]]; then
+            echo "Telemetrygen metrics found in the Prometheus instance"
+          else
+            echo "Telemetrygen metrics not found in Prometheus instance"
+            exit 1
+          fi
+        volumeMounts:
+        - name: prometheus-ca
+          mountPath: /etc/prometheus-ca
+          readOnly: true
+      restartPolicy: Never
+      volumes:
+      - name: prometheus-ca
+        secret:
+          secretName: prometheus-ca
+  backoffLimit: 4

--- a/tests/e2e-otel/prometheusremotewriteexporter/deploy-prometheus-assert.yaml
+++ b/tests/e2e-otel/prometheusremotewriteexporter/deploy-prometheus-assert.yaml
@@ -1,0 +1,22 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prometheus-receiver
+status:
+  availableReplicas: 1
+  readyReplicas: 1
+  replicas: 1
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus
+spec:
+  ports:
+  - port: 9090
+    protocol: TCP
+    targetPort: 9090
+  selector:
+    app: prometheus-receiver
+  type: ClusterIP

--- a/tests/e2e-otel/prometheusremotewriteexporter/deploy-prometheus.yaml
+++ b/tests/e2e-otel/prometheusremotewriteexporter/deploy-prometheus.yaml
@@ -1,0 +1,112 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: prometheus-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+
+---
+apiVersion: v1
+data:
+  tls.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUZJRENDQXdpZ0F3SUJBZ0lVQWtjSk5laXpqcHczOUc3QU1iTFEzWlJNNytBd0RRWUpLb1pJaHZjTkFRRUwKQlFBd0V6RVJNQThHQTFVRUF3d0lUWGxFWlcxdlEwRXdIaGNOTWpRd09ERTVNVEF4T0RFd1doY05NelF3T0RFMwpNVEF4T0RFd1dqQVZNUk13RVFZRFZRUUREQXB3Y205dFpYUm9aWFZ6TUlJQ0lqQU5CZ2txaGtpRzl3MEJBUUVGCkFBT0NBZzhBTUlJQ0NnS0NBZ0VBbk1KdEl0NUs4WDZDZUwxUnlXdEFnV2pldVFoc1VPbHBadmk3NlJGWTFaU1UKdG0xcUdkVEQvS2RjWFJBV2hqVmY3RjBCVDZ6blNWbkU5Q0Q0ZnNLY0s5WW1hc2d2RysvSDc2eGxPaVIxWlhmUAppSVA1L3JyOENpMWhLdXh3U2hQcnpJMkQraDFMNjllY2NrWXZTdGpoU2t5RXdBSWgrNzJpaUxYU3JQcE54RXhFCjdiVjV6Nm1sWXQrTmZEZTlFa01id092LzI2dzkzclplK0lMZEtaa3dYdWtubGhocHRiU0txM3N3ZnNzbjJza2sKemV1eGRnTTU5TWYydUFHWERWTXFTQ3dHSUFEUmJMVGRNK1JEdnBRZEp3TzNaZ29SM1ZMRldmR1Q1WWpXOWxjbgpWUXl6ejVGd2NScXIvWVZNVjM1QkkreU1SMUdvTXlCVUc5S1QxQzZ3MkFoWnVjMFRWWVhHN0tMN2V6ZWJ0L0NMClRBRG9VVnRMZFVCUU9Dd0M2QVBNdk5KaGZBT0lRQWtFZTlMSDB5R0dQUkdPRU81Vm9UWC84ZVlKbXVSZzgyYjQKeFJ5OTJGTHpDMlhBbVBYeHYvVnJ3SHpkVUhFL2RzRlVDQ2FZRFhBL3k2OTNhaCtGeVRuaVhBbHcwSFEzdVYvdQpCRHdjQUI2d0NMeG5jWkFFMVlSSVdDd1JRa1ExcWNoMDd1YUoxNllXUXplMFhHandXWTNsNzlIYVpGK3BqS3FjCm1yOW1XZm1nQWZPUmNRVWdPU2taUmo5VEdMNWxVUlFnQTJaQ1B6SWRRZzlObytpQTBFU1YrV1ZXcElUVFM0UW0KZDVRR0tlMVZVbDZ3Wmt5bmhOU1g1R01ueTA3dlJRcEV0algxUlBBWXFEZHdJVDBNdmtSN0cxamk0MVZiSlhjQwpBd0VBQWFOcU1HZ3dIUVlEVlIwT0JCWUVGRFdMVnFuVm1ZWHVOT044QmZpT2ovQ2pKNUdxTUI4R0ExVWRJd1FZCk1CYUFGQW9pVTM1Njk1ckhyazFvVjQxbGMybzNoZkYwTUE4R0ExVWRFd0VCL3dRRk1BTUJBZjh3RlFZRFZSMFIKQkE0d0RJSUtjSEp2YldWMGFHVjFjekFOQmdrcWhraUc5dzBCQVFzRkFBT0NBZ0VBUkZFODh4RG9Pd3MzVXFCUgpKaTh3bUlPbmU3Z2dGd1JkTHYrU2diYkpvanFLaXcyLytKaUhZZmYweXdRYSs3dXFTaVN0Wjl3NmJ6TGp5T0x6CjJOazdST0xacERqVDhWbnJnM2xEMlBna0NWRjJyWHhXdGRMWGlHNjlTc0cyNFdPNXVZNzk4ZVdac1lIckhsUlEKNnJuNzNtemxHMUN1VDFmVGphRmNKVXhiSHBOcXpQRXkzOFJ6bUlsWEVSSWlVRE0xUStTQXhiNHNjZ1B4eHhWLwpMa1ZBZmdhdjNYZ3cxanlBZDFOQjZwQkFFZWdkOXJGckpHVXk5MWZTNTZZdG9VZlM0bHNBTFlNcmhHVUxrWk5SCjNBalRtU3dDODVoTmhiQXFWMzhzZWl2K1Y3VHl2TUtvMElDN0E3UW52ZnhTb1A3bEQydjNFTVJmb01TV3Jmb2MKTWFGbVdpUEYzcll4OHF5ZU5lRlE0Tm9hQmtRTGZUZW5TaEtYY1JLRWs0ZnZja3luYnU5QjZpdmszY203OWp5OQo4WkRaUGpkdzliUUtXUW9jY1hYVkNxaXZUOHNISWR2NkxmTk5pZjhLVVREeTBpRlVXK0lGZ2tBeFlwRFlmakY1CmlyUjFZU3YzYlphZ3ZJWXpXQUVXcUg4MHdTRHd2bEU4RS9tY296dm9kSkJjNXR3VTRHYlZRK0VyNWNhVS9NNXMKcHVqcHJhSjhPTE5UTHFMamdTNTZMeDdMS0ZiczJpQVdMNzI0QVN1RDhUNVcya2NENHIrTFFMbGlTK3hTT0h0VAo3N0xROXh3QURBY0QxODUzbi92QmJsREJZdTY3MG12blRQVGVBejBteml1NmRwTzMrLzFqc2tvTnpjYzBRbU1uCmdkN284Ukh1cXhRT3laRjNXb0kwWlpuT1Qxbz0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
+  tls.key: LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1JSUpRd0lCQURBTkJna3Foa2lHOXcwQkFRRUZBQVNDQ1Mwd2dna3BBZ0VBQW9JQ0FRQ2N3bTBpM2tyeGZvSjQKdlZISmEwQ0JhTjY1Q0d4UTZXbG0rTHZwRVZqVmxKUzJiV29aMU1QOHAxeGRFQmFHTlYvc1hRRlByT2RKV2NUMApJUGgrd3B3cjFpWnF5QzhiNzhmdnJHVTZKSFZsZDgrSWcvbit1dndLTFdFcTdIQktFK3ZNallQNkhVdnIxNXh5ClJpOUsyT0ZLVElUQUFpSDd2YUtJdGRLcytrM0VURVR0dFhuUHFhVmkzNDE4TjcwU1F4dkE2Ly9ickQzZXRsNzQKZ3QwcG1UQmU2U2VXR0dtMXRJcXJlekIreXlmYXlTVE42N0YyQXpuMHgvYTRBWmNOVXlwSUxBWWdBTkZzdE4wego1RU8rbEIwbkE3ZG1DaEhkVXNWWjhaUGxpTmIyVnlkVkRMUFBrWEJ4R3F2OWhVeFhma0VqN0l4SFVhZ3pJRlFiCjBwUFVMckRZQ0ZtNXpSTlZoY2Jzb3Z0N041dTM4SXRNQU9oUlcwdDFRRkE0TEFMb0E4eTgwbUY4QTRoQUNRUjcKMHNmVElZWTlFWTRRN2xXaE5mL3g1Z21hNUdEelp2akZITDNZVXZNTFpjQ1k5ZkcvOVd2QWZOMVFjVDkyd1ZRSQpKcGdOY0QvTHIzZHFINFhKT2VKY0NYRFFkRGU1WCs0RVBCd0FIckFJdkdkeGtBVFZoRWhZTEJGQ1JEV3B5SFR1CjVvblhwaFpETjdSY2FQQlpqZVh2MGRwa1g2bU1xcHlhdjJaWithQUI4NUZ4QlNBNUtSbEdQMU1Zdm1WUkZDQUQKWmtJL01oMUNEMDJqNklEUVJKWDVaVmFraE5OTGhDWjNsQVlwN1ZWU1hyQm1US2VFMUpma1l5ZkxUdTlGQ2tTMgpOZlZFOEJpb04zQWhQUXkrUkhzYldPTGpWVnNsZHdJREFRQUJBb0lDQUEyS0czd0tBQ1lZbTdOTEFzL25WQlI1ClZ0ZGJlMk9IcllObjAyOGZnUEU5bXBTaElhdG1mYUVLWVlkbU50UFRzMXZLY3EwTGpaUi96T3ViRjJ0M2FwNjgKcWVmS0w0dDFxK3F2RkxVdlpmWmtJVWcwd2ZoMjlRTDZCV3o4Sy95eCtNbGJwYjBLSDc4WWlkb3k1cTNMeXJXcwpvMENrVG9RY1RuZ0pZRTl4ZFJzUnpWaE10dDh4VTJnVlQvYWRKOWIyZGVTMVhZMS9OSDdTZUtSMVJSM3RMY2pjCjBYNzh6OUNTYmZHK3U2TVA3L3JOS2NFaGJOdjVEbDN1a1lnMkZ2SmZMd1U1ekRPaWJuUTVzT3RrK1ZieUd3eCsKSFM2U2l4VjNLeldJRUpLZ1BaVGNWVGphMW9NRW1GWWtqQnRqRW9OeUU3VkRIcUNnVkd0S0RRbTBKL0dKTU52dApQWEdCSENrdGovZTRSV2ZMcEVEVitCZ3hEemViN0hyM0JoNjVQM3NWWFBzTHU0MnZsaUl2TVVhV0Y3Z3lVMGZFCnhqREJNMTZDT2FQQlJ1bUFnNEVCNG1sYUdZYURibngzVDcxV0FWaTZVSThmSStLMEJ2aFV1WEplRERCYWk4TmoKWmhmc0liMTRGQ25jalV5Y3NhK1BxQ0o4aEtlT0ZxSGkzYzE1dU9kN1d1RjY1N2k2RFA3Si95MUZHTmxhdTBzbQpZZnlqakFsQ0wxSzhwSkkrdmE1R3MyZGhCeUp5QjBCOFJleDU2b0w3QitGclNkYmtWTnQvVUU3akdxbTB3S0FmCkd6aDRac2o5c1BwNUNyZWsrQWVVdnMwVkMrYThSR1E4cVRaRGtLWlBWZGc4UU1oUldHNFhIUSs0SXIwUzJ2dzMKZXJURUhNOTRGVm0rQzdPcFN2b1JBb0lCQVFEVTNWVTIzZHpwQ3pwWFM0ZkI1VTF0ZlRid3A0Ylo5cFl0YVRFdgpvaUFWajZjTEJOR2JzUWFDZzhSMThSZnNrS253OWh1YjdpYjMzNFE2RDlJeXpEblBLRGNXUTJLYmpRbDdLc0h3ClVTelR5MkdTUVNaYTdRdGxKZFVHeEtpNVBRK0RnNDQ0bjJqc0VpUGtvRlNQdGs3Mkt2QXBQcjBvWlZhaVloQmMKY1dtYmUyQWRVdzNRM08wb1Q5UklsVmQ0QWtVYTdVRzNxU0VGU1lwYU5iM0pFaXhacjlsKysxZHluY2lnVmhtQgpZV2h5RURTWG5aZlBMNEcrUzl4VTBEZFVEc0V2M05paG1sdk5Qa0NZcXVqcHlTZ3hJQTFLenEvdnRCWis5OTU4CkY0eTV4S2lyUS9YRDFiWVlyQnhKeldVVTdRVHltRUplZ2J2dEJJZ0lrODFIL0VzbkFvSUJBUUM4aG83QjNlYTAKUG5RcTJRa1pJaVVKQkVMVExnOWEzUEFaNHM5akIvY2hkQ3lRRjNsYUgzWGpEeGpER2xTaUMyL2szL3FZZWM2YgpZQldmQXRFRXdDK1hoajBBdzBwcUxQVzh0NWdmNVNZaFVjdEVwMjdFTHl3Z010cVNteU1hdW1COTdNb00zQW1kClVHb0taVE9DV2pHR3ZpbzZORXVMUWJnMUNPb1pOdmlTZUpYV1NzNDZhNGtMeUpyNlRQRVZEOFQyTjNkdEhYeC8KY3ZOWGhOeTFrd0xjMG9VM3RpR0ZzQzhVazJLT2s5VThVbUhQWERoUkhNN090QUs3dDhiK3Q1dWl6Tk1wenZ6WQpaZnV2OTI2bFRFYytZb1pzVzVsZXArSENaTzhxWEtURzhuVmFva0R5MWh0dmM4dU1lNVBsTlRqc0hTcjRRQmJQCm90QmxTOUlPUHdVeEFvSUJBUUNocU9aS29QeGcwSElpVWU1c1J5VWlmZkgzbW9ORGpZNUlOcGR3UVlSMFc0RFYKVVhlTzhrYXJZRDhZQTEzVC81blFzbGdOZURTSUUyeHNYQStiSEpiYXlRUHRHSWdPOG5HODVLQWRUc2pvb0pFZApiZlVmSU4rQ2xkVFBLeE9vZXNNSmNpUFV4TnYrVFZpTkRXYXJMaDJSdnRKZHdKUVAxY2FSMUQvd3RRRXJYK3VDCjJjeW9UdUNkdU9MVHJQZWM0THh5MHJVU01wUXRXOGlDOGtXTUt3MGJuLzFoL3FoUEY1MkNoMkVmYlViUk9aVjMKZit3SElXRTdrSWxvc0NrVTRZKytOYzhnREFha1BSNzUwdkxJZWtqWDVpdXlJSDVsWVRPa2djS3FJNGh3blBZcgorNVR1Z2FPbDRUQXFySjZUNGQzY0Q5NTN2N2RsTGdmUjI4NFBXWUFKQW9JQkFRQ3lPWExVQy9lQ0JsakQrUklFCjFLYTJjM1RKT0E0RUZFSlg5bmVnWTNOYUNQM242b2txamZ0Z2dIRWtZTXdKdFU0K3pRK1cvZkE0S3duRm5XQUUKWWJ1Y1A2ZUVCUnRnYk1pVGMrMDRtZVVHTXRFN1FoNFJFWmRoaVRIZ3p4RE12ODFndm0zMDRqK2tuTlRpcHZHZgpGYTBrZUxwcTgrMUc1UVpEL1AxeWdPbFZidklYOS9nbWVtckEzUkRGOTk4aHpocWh1YVlKWFlySTRkN3lxZ1FOCkU4SHRDSWd3TnRwU0RGRTEzbStaNGwvLyt0SEV1cVh5NkkwS0ZGdFJJMWZZamJOd29Mb3dHQ0lvWWFFaXBZUFEKZU9BUk5ndG1mT0hzL2tFTENXaWdYNXpYQjNleUN4bmplRTNQZTJTK2xrVW10cjN0V1ZXNkFyeU41cG1rYVoxWApJblRCQW9JQkFCem9mSEZuL0hkNU0yTTJGV2xaN3NKdThaNmVFLzhDVFJBTGlyVjNiSXVIa1p4RnMwaEdkSm9JClJoOC8rblAwWmsxYSs2UGpmK1ZpNHZkR2JzaDVESmx2T0pocGVRc2FGQ0crMjF5akxyVXpmNUJvaVUvd3BXa1AKbVJ1Zk9ZbU56Y1pXeWxZQ0FRdktvZFJFTEZFeFNrajFYOVBtQjQybWZGOVBjK3RUa1hORmhIQk4ySXNIZ0E4bAo5Q1hvYXZ2OWhrOHg5WmhhbnFsZURqa0FESGt3S3VnS0JZTFpsOEllbStQRVJHT1lwd2I1MU9PTVMzNlU3dVBhCnZ1T05IbjhEMTU2U2ducFczWHNJYTYxM3VCeDl0aVpDdFV6V2ZFalZXMkpteGo1TGkvSGExcFpVOUY5VHFQdk0KVmxqbWthejR1MENpN2VLWjdKZXgzVmFhTzZRZkJNdz0KLS0tLS1FTkQgUFJJVkFURSBLRVktLS0tLQo=
+kind: Secret
+metadata:
+  name: prometheus-certs
+type: kubernetes.io/tls
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-config
+data:
+  prometheus.yml: |
+    global:
+      scrape_interval: 15s
+    scrape_configs:
+      - job_name: 'prometheus'
+        static_configs:
+          - targets: ['localhost:9090']
+  web-config.yml: |
+    tls_server_config:
+      cert_file: /etc/prometheus/certs/tls.crt
+      key_file: /etc/prometheus/certs/tls.key
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prometheus-receiver
+spec:
+  progressDeadlineSeconds: 600
+  revisionHistoryLimit: 10
+  replicas: 1
+  serviceAccountName: prometheus
+  selector:
+    matchLabels:
+      app: prometheus-receiver
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: prometheus-receiver
+    spec:
+      containers:
+        - name: prometheus
+          image: quay.io/prometheus/prometheus:v2.53.2
+          args:
+            - --config.file=/etc/prometheus/prometheus.yml
+            - --storage.tsdb.path=/prometheus
+            - --web.config.file=/etc/prometheus/web-config.yml
+            - --web.enable-lifecycle
+            - --web.enable-remote-write-receiver
+          ports:
+            - name: web
+              containerPort: 9090
+          volumeMounts:
+            - name: config-volume
+              mountPath: /etc/prometheus
+            - name: storage-volume
+              mountPath: /prometheus
+            - name: certs-volume
+              mountPath: /etc/prometheus/certs
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          securityContext:
+            runAsNonRoot: true
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      terminationGracePeriodSeconds: 30
+      volumes:
+        - name: config-volume
+          configMap:
+            name: prometheus-config
+        - name: storage-volume
+          persistentVolumeClaim:
+            claimName: prometheus-pvc
+        - name: certs-volume
+          secret:
+            secretName: prometheus-certs
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus
+spec:
+  selector:
+    app: prometheus-receiver
+  ports:
+    - protocol: TCP
+      port: 9090
+      targetPort: 9090

--- a/tests/e2e-otel/prometheusremotewriteexporter/generate-metrics-assert.yaml
+++ b/tests/e2e-otel/prometheusremotewriteexporter/generate-metrics-assert.yaml
@@ -1,0 +1,6 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: telemetrygen-metrics
+status:
+  active: 1

--- a/tests/e2e-otel/prometheusremotewriteexporter/generate-metrics.yaml
+++ b/tests/e2e-otel/prometheusremotewriteexporter/generate-metrics.yaml
@@ -1,0 +1,25 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: telemetrygen-metrics
+spec:
+  completions: 1
+  parallelism: 1
+  template:
+    metadata:
+      labels:
+        app: telemetrygen-metrics
+    spec:
+      containers:
+        - name: telemetrygen-metrics
+          image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
+          command: ["./telemetrygen"]
+          args:
+            - "--otlp-endpoint=otel-collector:4317"
+            - "--otlp-insecure=true"
+            - "--duration=30s"
+            - "--rate=1"
+            - "--otlp-attributes=telemetrygen=\"metrics\""
+            - "--otlp-header=telemetrygen=\"metrics\""
+            - "metrics"
+      restartPolicy: Never

--- a/tests/e2e-otel/prometheusremotewriteexporter/otel-collector-assert.yaml
+++ b/tests/e2e-otel/prometheusremotewriteexporter/otel-collector-assert.yaml
@@ -1,0 +1,32 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: otel-collector
+status:
+  availableReplicas: 1
+  readyReplicas: 1
+  replicas: 1
+  updatedReplicas: 1
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: otel-collector
+spec:
+  ports:
+  - appProtocol: grpc
+    name: otlp-grpc
+    port: 4317
+    protocol: TCP
+    targetPort: 4317
+  - appProtocol: http
+    name: otlp-http
+    port: 4318
+    protocol: TCP
+    targetPort: 4318
+  selector:
+    app.kubernetes.io/component: opentelemetry-collector
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/part-of: opentelemetry
+  type: ClusterIP

--- a/tests/e2e-otel/prometheusremotewriteexporter/otel-collector.yaml
+++ b/tests/e2e-otel/prometheusremotewriteexporter/otel-collector.yaml
@@ -1,0 +1,42 @@
+apiVersion: v1
+data:
+  ca.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUZCekNDQXUrZ0F3SUJBZ0lVSm9wazRvUkNqU05NSnFJaXFYb2k2cmxneWlBd0RRWUpLb1pJaHZjTkFRRUwKQlFBd0V6RVJNQThHQTFVRUF3d0lUWGxFWlcxdlEwRXdIaGNOTWpRd09ERTVNVEF4T0RFd1doY05NelF3T0RFMwpNVEF4T0RFd1dqQVRNUkV3RHdZRFZRUUREQWhOZVVSbGJXOURRVENDQWlJd0RRWUpLb1pJaHZjTkFRRUJCUUFECmdnSVBBRENDQWdvQ2dnSUJBS3A3UTJPOVY5VlZwUnVkV2pueEcyeWNNcVEyZGV1dDU1VUxTcjRxTCsvSE9QSUEKTUFKRUxqbGtDdTFCRTBiTmV4L3hRbktnVDUvVVlxN3dyV3NRWC9VSW9wU2d1WGxaMy9JTnRuZ2lzbkhFT09ZSwprUlFuWDdQRHF3OG81V1ZoZEpNaStoQ3ZzNnRZbnRlbmdZcCtZNVFKSFdPbVBSUGxvMllOWHNiMG4rdGVwNXVqCm9wU3BzNTNYSmtRc1dvNWVtTktzMUNUdkdackVkZk95QWFIS0xjMlpYMGFQUmRLNEdpOGpzMWk5dk13amhtS3EKUUc2SVJXbUx4Z3N4dmxLbG1HMDNxRnY5cjI4QktGeU9HSUN0ZmVRQXRSaUhJa0lJSmQyUG9lUFN5dkxqRnJWRwpiRyswTnkvZEorQXpydFUrYnRZeVBMSmVqTHJubmc2enc0amp4aXd1bXYxdXFiMlRha29JaVNOZjZabFlnZ2U4CkdXb1hsYUlmR3hINVpyMmYvazE2cnRxNVM3VVNFQko5cHB6RU9NVjUwL2xrOGxWVEpsNmw3S2lBczRhZnZ2aHAKZHFoU3htN3pVRmREYy9xZlJ5NTZ5ZFJpYmI2Z0lwb25Ib3JrNTRDcld6K2hBaGI2ckV4eG5vSTVmSmZiM0UxNQo4VUw2OWx3TGV0a3B0dDhsdlAvSVFnRDRpU0FhakcrYVYvYnJlSjV6ZTRkL3lyZWNtWTVsYTd3T3ExNFVQOVdQCnZEWlBTdUgyZEhuV0RkTDM3YnRKaVZ2dWpTaUtFSm9tTGE3eXdKTG1hL2FmeTEybXhmcVV3ZWpKaDQrWitvUW4Ka0Q4SEIyM283SklJekU5TCtuelo1bnRxSkhsb1NJa3c1d0twVmNybUo5NkxuWHdLcmVMZnlpNXZJenYvQWdNQgpBQUdqVXpCUk1CMEdBMVVkRGdRV0JCUUtJbE4rZXZlYXg2NU5hRmVOWlhOcU40WHhkREFmQmdOVkhTTUVHREFXCmdCUUtJbE4rZXZlYXg2NU5hRmVOWlhOcU40WHhkREFQQmdOVkhSTUJBZjhFQlRBREFRSC9NQTBHQ1NxR1NJYjMKRFFFQkN3VUFBNElDQVFCQ2R1TytvWDNSQkpJZUR4TDVURnpCcTZQTkRIYXJMeFErSTFVekhUNktUTTl4S3hQZgpSWkFRdmU4ZlE0a1hMdnAwL3h1MEZaZU9LZUh0MEFHS09CaGZYcTA4eUZCRys3a0hwSzhWUWtnUmtRT0w5ZkJEClRHbVdHZld5bXBWYTEvM1pBaUdNVTYzVmF5UVpCZnp5Nm0yR3NscVdLSEZYRXhSak1BaUZUcjZoWTJSSDIycTUKNGY4alZ4dUMyWCtqVHZ2N0tIMGVqUXp6SERqYlpGWitsbFdyMnYzSkY3Z21XUENtV1lTVHF3VTlkSzY4QnhvNgpwY0cxTDRiazF6Z0wvMkhCOVR3ZG8xYy9xT1N6amE0eVc5dkF0TFBGNm5MTjFTR1lCQlh2UTlZc1JCTklHb3lxCk1DUXJjbFRrKy9mL0R5WE1idVYvRmFmWlp2R3ZPd1phOXlaQUhCM2c3VEZTUzBTdnhLSnMzaXJrLzV1NnRjWVAKTXZLYndTbEhTNFlYaVNPKzc2dG8wbC9qc1ZyM0lqL25GUzBwdUtpZk1ZN3o3S3hKaXIvRlJ5VGxzM0NPZjJyaApnZ0ZiZDJobmZmNTVsSzJNNFAxTmY0KzJvVllrYWJ5UFlSR05EZ3NSL0RCSWRjTHl2d0kvdXNNMlc0eC9zRWtYCi92T1pQUFJ4Y1BYNjBxTWxOYXRnQVJsNjJhaHBsYlEwam4rS244THl3aVZXdm9LRE53eXFvOGRwWndRYmpzQkIKMU1nZk9lOWxKQnVNLytQZGtRWk8vOTg4MmUyYjgzVkwweXFyd044M0V1U2RkVDJYQXE5VWg1UU5zNFo0dmQxMwpITU5zMWYxVWFLdWZsYWUyUTMrZ1dwTEVoUklkKzdkSVFnaTNjSUxiZDZqWDdzZ1ZoM0Q5elVJdEdnPT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
+kind: Secret
+metadata:
+  name: prometheus-ca
+type: Opaque
+
+---
+apiVersion: opentelemetry.io/v1alpha1
+kind: OpenTelemetryCollector
+metadata:
+  name: otel
+spec:
+  volumeMounts:
+    - name: certs-volume
+      mountPath: /certs
+      readOnly: true
+  volumes:
+    - name: certs-volume
+      secret:
+        secretName: prometheus-ca
+  mode: deployment
+  config: |
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+          http:
+    processors:
+    exporters:
+      prometheusremotewrite:
+        endpoint: "https://prometheus:9090/api/v1/write"
+        tls:
+          ca_file: /certs/ca.crt
+        resource_to_telemetry_conversion:
+          enabled: true
+    service:
+      pipelines:
+        metrics:
+          receivers: [otlp]
+          exporters: [prometheusremotewrite]

--- a/tests/e2e-otel/routingconnector/chainsaw-test.yaml
+++ b/tests/e2e-otel/routingconnector/chainsaw-test.yaml
@@ -1,0 +1,46 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: routingconnector
+spec:
+  namespace: chainsaw-routecnctr
+  steps:
+  - name: Create Tempo monolithic instances
+    try:
+    - apply:
+        file: install-tempo.yaml
+    - assert:
+        file: install-tempo-assert.yaml
+  - name: Check the status of Tempo Monolithc instance red
+    try:
+    - script:
+        timeout: 5m
+        content: kubectl get --namespace chainsaw-routecnctr tempomonolithics red -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}'
+  - name: Check the status of Tempo Monolithc instance blue
+    try:
+    - script:
+        timeout: 5m
+        content: kubectl get --namespace chainsaw-routecnctr tempomonolithics blue -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}'
+  - name: Check the status of Tempo Monolithc instance green
+    try:
+    - script:
+        timeout: 5m
+        content: kubectl get --namespace chainsaw-routecnctr tempomonolithics green -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}'
+  - name: Create OTEL collector instance
+    try:
+    - apply:
+        file: otel-collector.yaml
+    - assert:
+        file: otel-collector-assert.yaml
+  - name: Generate and send traces to the OTEL collector
+    try:
+    - apply:
+        file: generate-traces.yaml
+    - assert:
+        file: generate-traces-assert.yaml
+  - name: Verify traces in the Tempo instances
+    try:
+    - apply:
+        file: verify-traces.yaml
+    - assert:
+        file: verify-traces-assert.yaml

--- a/tests/e2e-otel/routingconnector/generate-traces-assert.yaml
+++ b/tests/e2e-otel/routingconnector/generate-traces-assert.yaml
@@ -1,0 +1,25 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: generate-traces-blue
+  namespace: chainsaw-routecnctr
+status:
+  succeeded: 1
+
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: generate-traces-red
+  namespace: chainsaw-routecnctr
+status:
+  succeeded: 1
+
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: generate-traces-green
+  namespace: chainsaw-routecnctr
+status:
+  succeeded: 1

--- a/tests/e2e-otel/routingconnector/generate-traces.yaml
+++ b/tests/e2e-otel/routingconnector/generate-traces.yaml
@@ -1,0 +1,61 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: generate-traces-red
+spec:
+  template:
+    spec:
+      containers:
+      - name: telemetrygen
+        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
+        args:
+        - traces
+        - --otlp-endpoint=routing-collector.chainsaw-routecnctr.svc:4317
+        - --otlp-insecure=true
+        - --traces=5
+        - --service=red
+        - --otlp-attributes=X-Tenant="red"
+      restartPolicy: Never
+  backoffLimit: 4
+
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: generate-traces-green
+spec:
+  template:
+    spec:
+      containers:
+      - name: telemetrygen
+        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
+        args:
+        - traces
+        - --otlp-endpoint=routing-collector.chainsaw-routecnctr.svc:4317
+        - --otlp-insecure=true
+        - --traces=5
+        - --service=green
+        - --otlp-attributes=X-Tenant="green"
+      restartPolicy: Never
+  backoffLimit: 4
+
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: generate-traces-blue
+spec:
+  template:
+    spec:
+      containers:
+      - name: telemetrygen
+        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
+        args:
+        - traces
+        - --otlp-endpoint=routing-collector.chainsaw-routecnctr.svc:4317
+        - --otlp-insecure=true
+        - --traces=5
+        - --service=blue
+        - --otlp-attributes=X-Tenant="blue"
+      restartPolicy: Never
+  backoffLimit: 4

--- a/tests/e2e-otel/routingconnector/install-tempo-assert.yaml
+++ b/tests/e2e-otel/routingconnector/install-tempo-assert.yaml
@@ -1,0 +1,31 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: tempo-blue
+  namespace: chainsaw-routecnctr
+status:
+  availableReplicas: 1
+  readyReplicas: 1
+  replicas: 1
+
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: tempo-red
+  namespace: chainsaw-routecnctr
+status:
+  availableReplicas: 1
+  readyReplicas: 1
+  replicas: 1
+
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: tempo-green
+  namespace: chainsaw-routecnctr
+status:
+  availableReplicas: 1
+  readyReplicas: 1
+  replicas: 1

--- a/tests/e2e-otel/routingconnector/install-tempo.yaml
+++ b/tests/e2e-otel/routingconnector/install-tempo.yaml
@@ -1,0 +1,31 @@
+apiVersion: tempo.grafana.com/v1alpha1
+kind: TempoMonolithic
+metadata:
+  name: red
+spec:
+  jaegerui:
+    enabled: true
+    route:
+      enabled: true
+
+---
+apiVersion: tempo.grafana.com/v1alpha1
+kind: TempoMonolithic
+metadata:
+  name: blue
+spec:
+  jaegerui:
+    enabled: true
+    route:
+      enabled: true
+
+---
+apiVersion: tempo.grafana.com/v1alpha1
+kind: TempoMonolithic
+metadata:
+  name: green
+spec:
+  jaegerui:
+    enabled: true
+    route:
+      enabled: true

--- a/tests/e2e-otel/routingconnector/otel-collector-assert.yaml
+++ b/tests/e2e-otel/routingconnector/otel-collector-assert.yaml
@@ -1,0 +1,28 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: routing-collector
+  namespace: chainsaw-routecnctr
+status:
+  availableReplicas: 1
+  readyReplicas: 1
+  replicas: 1
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: routing-collector
+  namespace: chainsaw-routecnctr
+spec:
+  ports:
+  - appProtocol: grpc
+    name: otlp-grpc
+    port: 4317
+    protocol: TCP
+    targetPort: 4317
+  selector:
+    app.kubernetes.io/component: opentelemetry-collector
+    app.kubernetes.io/instance: chainsaw-routecnctr.routing
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/part-of: opentelemetry

--- a/tests/e2e-otel/routingconnector/otel-collector.yaml
+++ b/tests/e2e-otel/routingconnector/otel-collector.yaml
@@ -1,0 +1,56 @@
+apiVersion: opentelemetry.io/v1beta1
+kind: OpenTelemetryCollector
+metadata:
+  name: routing
+spec:
+  config:
+    receivers:
+      otlp:
+        protocols:
+          grpc: {}
+
+    exporters:
+      otlp/red:
+        endpoint: tempo-red.chainsaw-routecnctr.svc:4317
+        tls:
+          insecure: true
+      otlp/green:
+        endpoint: tempo-green.chainsaw-routecnctr.svc:4317
+        tls:
+          insecure: true
+      otlp/blue:
+        endpoint: tempo-blue.chainsaw-routecnctr.svc:4317
+        tls:
+          insecure: true
+
+    processors:
+
+    connectors:
+      routing:
+        error_mode: ignore
+        match_once: false
+        default_pipelines: [traces/green]
+        table:
+          - statement: route() where attributes["X-Tenant"] == "red"
+            pipelines: [traces/red]
+          - statement: route() where attributes["X-Tenant"] == "blue"
+            pipelines: [traces/blue]
+
+    service:
+      pipelines:
+        traces/in:
+          receivers: [otlp]
+          processors: []
+          exporters: [routing]
+        traces/red:
+          receivers: [routing]
+          processors: []
+          exporters: [otlp/red]
+        traces/blue:
+          receivers: [routing]
+          processors: []
+          exporters: [otlp/blue]
+        traces/green:
+          receivers: [routing]
+          processors: []
+          exporters: [otlp/green]

--- a/tests/e2e-otel/routingconnector/verify-traces-assert.yaml
+++ b/tests/e2e-otel/routingconnector/verify-traces-assert.yaml
@@ -1,0 +1,25 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: verify-traces-blue
+  namespace: chainsaw-routecnctr
+status:
+  succeeded: 1
+
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: verify-traces-green
+  namespace: chainsaw-routecnctr
+status:
+  succeeded: 1
+
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: verify-traces-red
+  namespace: chainsaw-routecnctr
+status:
+  succeeded: 1

--- a/tests/e2e-otel/routingconnector/verify-traces.yaml
+++ b/tests/e2e-otel/routingconnector/verify-traces.yaml
@@ -1,0 +1,73 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: verify-traces-red
+spec:
+  template:
+    spec:
+      containers:
+      - name: verify-traces-red
+        image: ghcr.io/grafana/tempo-operator/test-utils:main
+        command:
+        - /bin/bash
+        - -eux
+        - -c
+        args:
+        - |
+          curl -v -G http://tempo-red-jaegerui.chainsaw-routecnctr.svc:16686/api/traces --data-urlencode "service=red" | tee /tmp/jaeger.out
+          num_traces=$(jq ".data | length" /tmp/jaeger.out)
+          if [[ "$num_traces" -ne 5 ]]; then
+            echo && echo "The Jaeger API returned $num_traces instead of 10 traces."
+            exit 1
+          fi
+      restartPolicy: Never
+
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: verify-traces-blue
+spec:
+  template:
+    spec:
+      containers:
+      - name: verify-traces-blue
+        image: ghcr.io/grafana/tempo-operator/test-utils:main
+        command:
+        - /bin/bash
+        - -eux
+        - -c
+        args:
+        - |
+          curl -v -G http://tempo-blue-jaegerui.chainsaw-routecnctr.svc:16686/api/traces --data-urlencode "service=blue" | tee /tmp/jaeger.out
+          num_traces=$(jq ".data | length" /tmp/jaeger.out)
+          if [[ "$num_traces" -ne 5 ]]; then
+            echo && echo "The Jaeger API returned $num_traces instead of 10 traces."
+            exit 1
+          fi
+      restartPolicy: Never
+
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: verify-traces-green
+spec:
+  template:
+    spec:
+      containers:
+      - name: verify-traces-green
+        image: ghcr.io/grafana/tempo-operator/test-utils:main
+        command:
+        - /bin/bash
+        - -eux
+        - -c
+        args:
+        - |
+          curl -v -G http://tempo-green-jaegerui.chainsaw-routecnctr.svc:16686/api/traces --data-urlencode "service=green" | tee /tmp/jaeger.out
+          num_traces=$(jq ".data | length" /tmp/jaeger.out)
+          if [[ "$num_traces" -ne 5 ]]; then
+            echo && echo "The Jaeger API returned $num_traces instead of 10 traces."
+            exit 1
+          fi
+      restartPolicy: Never

--- a/tests/e2e-otel/transformprocessor/chainsaw-test.yaml
+++ b/tests/e2e-otel/transformprocessor/chainsaw-test.yaml
@@ -1,0 +1,36 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: transformprocessor
+spec:
+  namespace: chainsaw-tprocssr
+  steps:
+  - name: Create Tempo monolithic instances
+    try:
+    - apply:
+        file: install-tempo.yaml
+    - assert:
+        file: install-tempo-assert.yaml
+  - name: Check the status of Tempo Monolithc instance tprocssr
+    try:
+    - script:
+        timeout: 5m
+        content: kubectl get --namespace chainsaw-tprocssr tempomonolithics tprocssr -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}'
+  - name: Create OTEL collector instance
+    try:
+    - apply:
+        file: otel-collector.yaml
+    - assert:
+        file: otel-collector-assert.yaml
+  - name: Generate and send traces to the OTEL collector
+    try:
+    - apply:
+        file: generate-traces.yaml
+    - assert:
+        file: generate-traces-assert.yaml
+  - name: Verify traces in the Tempo instances
+    try:
+    - apply:
+        file: verify-traces.yaml
+    - assert:
+        file: verify-traces-assert.yaml

--- a/tests/e2e-otel/transformprocessor/generate-traces-assert.yaml
+++ b/tests/e2e-otel/transformprocessor/generate-traces-assert.yaml
@@ -1,0 +1,7 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: generate-traces-green
+  namespace: chainsaw-tprocssr
+status:
+  succeeded: 1

--- a/tests/e2e-otel/transformprocessor/generate-traces.yaml
+++ b/tests/e2e-otel/transformprocessor/generate-traces.yaml
@@ -1,0 +1,20 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: generate-traces-green
+spec:
+  template:
+    spec:
+      containers:
+      - name: telemetrygen
+        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.92.0
+        args:
+        - traces
+        - --otlp-endpoint=tprocssr-collector.chainsaw-tprocssr.svc:4317
+        - --otlp-insecure=true
+        - --traces=1
+        - --service=green
+        - --otlp-attributes=X-Tenant="green"
+        - --otlp-attributes=generator="green-1"
+      restartPolicy: Never
+  backoffLimit: 4

--- a/tests/e2e-otel/transformprocessor/install-tempo-assert.yaml
+++ b/tests/e2e-otel/transformprocessor/install-tempo-assert.yaml
@@ -1,0 +1,9 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: tempo-tprocssr
+  namespace: chainsaw-tprocssr
+status:
+  availableReplicas: 1
+  readyReplicas: 1
+  replicas: 1

--- a/tests/e2e-otel/transformprocessor/install-tempo.yaml
+++ b/tests/e2e-otel/transformprocessor/install-tempo.yaml
@@ -1,0 +1,9 @@
+apiVersion: tempo.grafana.com/v1alpha1
+kind: TempoMonolithic
+metadata:
+  name: tprocssr
+spec:
+  jaegerui:
+    enabled: true
+    route:
+      enabled: true

--- a/tests/e2e-otel/transformprocessor/otel-collector-assert.yaml
+++ b/tests/e2e-otel/transformprocessor/otel-collector-assert.yaml
@@ -1,0 +1,28 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tprocssr-collector
+  namespace: chainsaw-tprocssr
+status:
+  availableReplicas: 1
+  readyReplicas: 1
+  replicas: 1
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: tprocssr-collector
+  namespace: chainsaw-tprocssr
+spec:
+  ports:
+  - appProtocol: grpc
+    name: otlp-grpc
+    port: 4317
+    protocol: TCP
+    targetPort: 4317
+  selector:
+    app.kubernetes.io/component: opentelemetry-collector
+    app.kubernetes.io/instance: chainsaw-tprocssr.tprocssr
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/part-of: opentelemetry

--- a/tests/e2e-otel/transformprocessor/otel-collector.yaml
+++ b/tests/e2e-otel/transformprocessor/otel-collector.yaml
@@ -1,0 +1,42 @@
+apiVersion: opentelemetry.io/v1beta1
+kind: OpenTelemetryCollector
+metadata:
+  name: tprocssr
+spec:
+  config:
+    receivers:
+      otlp:
+        protocols:
+          grpc: {}
+
+    exporters:
+      otlp:
+        endpoint: tempo-tprocssr.chainsaw-tprocssr.svc:4317
+        tls:
+          insecure: true
+
+    processors:
+      transform:
+        error_mode: ignore
+        trace_statements:
+          - context: resource
+            statements:
+              - keep_keys(attributes, ["service.name", "X-Tenant", "otel.library.name"])
+              - set(attributes["X-Tenant"], "blue") where attributes["X-Tenant"] == "green"
+              - limit(attributes, 100, [])
+              - truncate_all(attributes, 4096)
+          - context: span
+            statements:
+              - set(attributes["net.peer.ip"], "5.6.7.8") where attributes["net.peer.ip"] == "1.2.3.4"
+              - set(attributes["peer.service"], "modified-server") where attributes["peer.service"] == "telemetrygen-server"
+              - set(attributes["peer.service"], "modified-client") where attributes["peer.service"] == "telemetrygen-client"
+              - set(name, "modified-operation") where name == "okey-dokey"
+              - limit(attributes, 100, [])
+              - truncate_all(attributes, 4096)
+
+    service:
+      pipelines:
+        traces:
+          receivers: [otlp]
+          processors: [transform]
+          exporters: [otlp]

--- a/tests/e2e-otel/transformprocessor/verify-traces-assert.yaml
+++ b/tests/e2e-otel/transformprocessor/verify-traces-assert.yaml
@@ -1,0 +1,7 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: verify-traces
+  namespace: chainsaw-tprocssr
+status:
+  succeeded: 1

--- a/tests/e2e-otel/transformprocessor/verify-traces.yaml
+++ b/tests/e2e-otel/transformprocessor/verify-traces.yaml
@@ -1,0 +1,41 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: verify-traces
+spec:
+  template:
+    spec:
+      containers:
+      - name: verify-traces-green
+        image: ghcr.io/grafana/tempo-operator/test-utils:main
+        command:
+        - /bin/bash
+        - -eux
+        - -c
+        args:
+        - |
+          TRACE_JSON=$(curl -s -G http://tempo-tprocssr-jaegerui.chainsaw-tprocssr.svc:16686/api/traces --data-urlencode "service=green")
+          VALIDATE=$(echo $TRACE_JSON | jq '
+            .data[] | 
+            select(
+              .spans[] | 
+              (
+                (.operationName == "modified-operation") and 
+                (.tags[] | select(.key == "net.peer.ip" and .value == "5.6.7.8")) and 
+                (.tags[] | select(.key == "peer.service" and .value == "modified-client"))
+              )
+            ) and 
+            (
+              .processes[] | 
+              (
+                (.tags[] | select(.key == "X-Tenant" and .value == "blue"))
+              )
+            )
+          ')
+          if [ -n "$VALIDATE" ]; then
+            echo "Validation passed: The trace values match the transform processor settings."
+          else
+            echo "Validation failed: The trace values do not match the transform processor settings."
+            exit 1
+          fi
+      restartPolicy: Never


### PR DESCRIPTION
Move the additional OTEL tests for collector in openshift/distributed-tracing-qe to os-observability/redhat-opentelemetry-collector. Resolves https://issues.redhat.com/browse/TRACING-5022 

```
--- PASS: chainsaw (0.00s)
    --- PASS: chainsaw/countconnector (41.20s)
    --- PASS: chainsaw/k8sobjectsreceiver (52.88s)
    --- PASS: chainsaw/hostmetricsreceiver (55.90s)
    --- PASS: chainsaw/k8seventsreceiver (110.48s)
    --- PASS: chainsaw/transformprocessor (73.38s)
    --- PASS: chainsaw/otlpjsonfilereceiver (98.27s)
    --- PASS: chainsaw/routingconnector (90.18s)
    --- PASS: chainsaw/prometheusremotewriteexporter (53.09s)
    --- PASS: chainsaw/groupbyattrsprocessor (78.27s)
    --- PASS: chainsaw/k8sclusterreceiver (103.93s)
    --- PASS: chainsaw/journaldreceiver (98.39s)
    --- PASS: chainsaw/filestorageext (88.55s)
    --- PASS: chainsaw/forwardconnector (36.16s)
    --- PASS: chainsaw/loadbalancingexporter (44.25s)
    --- PASS: chainsaw/kubeletstatsreceiver (94.36s)
    --- PASS: chainsaw/filelog (127.32s)
    --- PASS: chainsaw/oidcauthextension (102.99s)
PASS
Tests Summary...
- Passed  tests 17
- Failed  tests 0
- Skipped tests 0
Done.
```
