### PR TITLE
Add OBI source as nested submodule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@ _build/README.md
 opentelemetry-collector.spec
 bin/**
 dist/**
-.obi-src/
+
 *.mod
 !**/go.mod
 *.pp

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule ".obi-src"]
+	path = .obi-src
+	url = https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation.git

--- a/Makefile
+++ b/Makefile
@@ -37,20 +37,15 @@ else
 OTELCOL_BUILDER=$(shell which ocb)
 endif
 
-OBI_VERSION := $(shell awk '/- gomod: go\.opentelemetry\.io\/obi / {print $$NF; exit}' manifest.yaml)
-OBI_REPO ?= https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation.git
 OBI_DIR ?= .obi-src
 
 .PHONY: ensure-obi
 ensure-obi:
 	@if [ -f $(OBI_DIR)/go.mod ]; then \
 		echo "OBI source already present at $(OBI_DIR)"; \
-	elif [ -f $(OBI_DIR)/.git ] || [ -d $(OBI_DIR)/.git ]; then \
+	else \
 		echo "Initialising OBI submodule at $(OBI_DIR)..."; \
 		git submodule update --init --depth 1 $(OBI_DIR); \
-	else \
-		echo "Cloning OBI $(OBI_VERSION) into $(OBI_DIR)..."; \
-		git clone --depth 1 --branch $(OBI_VERSION) $(OBI_REPO) $(OBI_DIR); \
 	fi
 
 .PHONY: generate-obi

--- a/Makefile
+++ b/Makefile
@@ -41,12 +41,8 @@ OBI_DIR ?= .obi-src
 
 .PHONY: ensure-obi
 ensure-obi:
-	@if [ -f $(OBI_DIR)/go.mod ]; then \
-		echo "OBI source already present at $(OBI_DIR)"; \
-	else \
-		echo "Initialising OBI submodule at $(OBI_DIR)..."; \
-		git submodule update --init --depth 1 $(OBI_DIR); \
-	fi
+	@echo "Ensuring OBI submodule at $(OBI_DIR)..."
+	git submodule update --init --depth 1 $(OBI_DIR)
 
 .PHONY: generate-obi
 generate-obi: ensure-obi

--- a/Makefile
+++ b/Makefile
@@ -43,15 +43,15 @@ OBI_DIR ?= .obi-src
 
 .PHONY: ensure-obi
 ensure-obi:
-	@if [ ! -d $(OBI_DIR) ]; then \
+	@if [ -f $(OBI_DIR)/go.mod ]; then \
+		echo "OBI source already present at $(OBI_DIR)"; \
+	elif [ -f $(OBI_DIR)/.git ] || [ -d $(OBI_DIR)/.git ]; then \
+		echo "Initialising OBI submodule at $(OBI_DIR)..."; \
+		git submodule update --init --depth 1 $(OBI_DIR); \
+	else \
 		echo "Cloning OBI $(OBI_VERSION) into $(OBI_DIR)..."; \
 		git clone --depth 1 --branch $(OBI_VERSION) $(OBI_REPO) $(OBI_DIR); \
-	elif [ ! -f $(OBI_DIR)/.obi-$(OBI_VERSION) ]; then \
-		echo "OBI version changed to $(OBI_VERSION); re-cloning..."; \
-		rm -rf $(OBI_DIR); \
-		git clone --depth 1 --branch $(OBI_VERSION) $(OBI_REPO) $(OBI_DIR); \
 	fi
-	@touch $(OBI_DIR)/.obi-$(OBI_VERSION)
 
 .PHONY: generate-obi
 generate-obi: ensure-obi

--- a/README.md
+++ b/README.md
@@ -9,6 +9,33 @@ This repository configures a build of the OpenTelemetry Collector with the suppo
 1. Update changelog in [RPM spec](./opentelemetry-collector.spec.in)
 1. Create a pull request with the changes, including changes in the `_build` directory.
 
+## Update OBI version
+
+The OpenTelemetry eBPF Instrumentation (OBI) receiver is pinned in two places
+that must be kept in sync:
+
+- **`manifest.yaml`** declares the module version, e.g. `go.opentelemetry.io/obi v0.10.0`.
+- **`.obi-src`** is a git submodule (see [`.gitmodules`](./.gitmodules)) pinned to a
+  specific commit. A `replace` directive in `manifest.yaml`
+  (`go.opentelemetry.io/obi => ../.obi-src`) redirects the module to this local
+  checkout, so the submodule commit is what actually gets built. The eBPF
+  artifacts are generated from it by `make generate-obi`.
+
+To bump to a new OBI release (e.g. `v0.11.0`):
+
+1. Move the submodule to the matching upstream tag or commit:
+   ```
+   git -C .obi-src fetch --tags
+   git -C .obi-src checkout v0.11.0
+   git add .obi-src
+   ```
+1. Update the module version string in [`manifest.yaml`](./manifest.yaml) to match
+   (`go.opentelemetry.io/obi v0.11.0`).
+1. Run `make build generate-schemas` or `make build-in-podman`. This regenerates the
+   OBI eBPF artifacts and the contents of the `_build` directory.
+1. Create a pull request with the changes, including the updated submodule pointer,
+   `manifest.yaml`, and the `_build` directory.
+
 ## Release
 
 ```


### PR DESCRIPTION
## Summary

- Replace the gitignored `.obi-src` clone directory with a git submodule pointing to `opentelemetry-ebpf-instrumentation` at v0.10.0
- Update `ensure-obi` Makefile target to handle submodule init, fallback to standalone clone
- Remove `.obi-src/` from `.gitignore`

## Why

The `replace go.opentelemetry.io/obi => ../.obi-src` directive in `_build/go.mod` fails during Konflux hermetic prefetch because `.obi-src` only existed at Docker build time (copied from a separate stage). With a nested submodule, Konflux's recursive `git submodule update --init --recursive` populates `.obi-src` before prefetch runs.
