### PR TITLE
TRACING-6641: add webhookeventreceiver to the distro

### DIFF
--- a/_build/build.log
+++ b/_build/build.log
@@ -1,7 +1,6 @@
-2026-08-10T10:38:45.137+0100	INFO	internal/command.go:97	OpenTelemetry Collector Builder	{"version": "v0.158.0+dirty"}
-2026-08-10T10:38:45.138+0100	INFO	internal/command.go:102	Using config file	{"path": "manifest.yaml"}
-2026-08-10T10:38:45.139+0100	INFO	builder/config.go:165	Using go	{"go-executable": "/usr/bin/go"}
-2026-08-10T10:38:45.142+0100	INFO	builder/main.go:110	Sources created	{"path": "./_build"}
-2026-08-10T10:38:45.940+0100	INFO	builder/main.go:231	Getting go modules
-2026-08-10T10:38:46.084+0100	INFO	builder/main.go:121	Compiling
-2026-08-10T10:39:02.247+0100	INFO	builder/main.go:153	Compiled	{"binary": "./_build/otelcol"}
+2026-08-19T14:17:02.071+0200	INFO	internal/command.go:97	OpenTelemetry Collector Builder	{"version": "v0.158.0+dirty"}
+2026-08-19T14:17:02.071+0200	INFO	internal/command.go:102	Using config file	{"path": "manifest.yaml"}
+2026-08-19T14:17:02.075+0200	INFO	builder/config.go:165	Using go	{"go-executable": "/usr/lib/golang/bin/go"}
+2026-08-19T14:17:02.085+0200	INFO	builder/main.go:110	Sources created	{"path": "./_build"}
+2026-08-19T14:17:12.981+0200	INFO	builder/main.go:231	Getting go modules
+2026-08-19T14:17:14.180+0200	INFO	builder/main.go:117	Generating source codes only, the distribution will not be compiled.

--- a/_build/components.go
+++ b/_build/components.go
@@ -68,6 +68,7 @@ import (
 	k8sclusterreceiver "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver"
 	k8sobjectsreceiver "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sobjectsreceiver"
 	otlpjsonfilereceiver "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/otlpjsonfilereceiver"
+	webhookeventreceiver "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/webhookeventreceiver"
 	collector "go.opentelemetry.io/obi/collector"
 )
 
@@ -138,6 +139,7 @@ func components() (otelcol.Factories, error) {
 		k8sclusterreceiver.NewFactory(),
 		k8sobjectsreceiver.NewFactory(),
 		otlpjsonfilereceiver.NewFactory(),
+		webhookeventreceiver.NewFactory(),
 		collector.NewFactory(),
 	)
 	if err != nil {
@@ -158,6 +160,7 @@ func components() (otelcol.Factories, error) {
 		k8sclusterreceiver.NewFactory().Type(): "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver v0.158.0",
 		k8sobjectsreceiver.NewFactory().Type(): "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sobjectsreceiver v0.158.0",
 		otlpjsonfilereceiver.NewFactory().Type(): "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/otlpjsonfilereceiver v0.158.0",
+		webhookeventreceiver.NewFactory().Type(): "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/webhookeventreceiver v0.158.0",
 		collector.NewFactory().Type(): "go.opentelemetry.io/obi v0.10.0",
 	})
 

--- a/_build/go.mod
+++ b/_build/go.mod
@@ -52,6 +52,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/otlpjsonfilereceiver v0.158.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.158.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusremotewritereceiver v0.158.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/webhookeventreceiver v0.158.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkinreceiver v0.158.0
 	github.com/pavolloffay/opentelemetry-mcp-server/modules/schemagen v0.0.0-20260710124846-8bb49fd6ccc7
 	go.opentelemetry.io/collector/component v1.64.0

--- a/_build/go.sum
+++ b/_build/go.sum
@@ -846,6 +846,8 @@ github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusrec
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.158.0/go.mod h1:v0iOLCt53Qx35O5XB8re3aUPvMEzE+PiJsfqxs2sx7g=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusremotewritereceiver v0.158.0 h1:Y/dH+sLOMsIxfWzJpI4iLsKk35ItrOHB97D5ejxpq0k=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusremotewritereceiver v0.158.0/go.mod h1:mhomqsbEaCIc0Oqq8NuZLgy4MRSLnOiWTcmMftxOxC0=
+github.com/open-telemetry/opentelemetry-collector-contrib/receiver/webhookeventreceiver v0.158.0 h1:Crfr87KaosqXbmScZfPSEfTYbY5d8EKl2m2owi6aQxU=
+github.com/open-telemetry/opentelemetry-collector-contrib/receiver/webhookeventreceiver v0.158.0/go.mod h1:2YzH+GPycyjcUVLwfgoNTE1vkzBnZP+Z2rJ0cRkxrfo=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkinreceiver v0.158.0 h1:0F4+ldWkOeCjgee8W5gphTSKv0F9bKK1w81kbtXXviA=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkinreceiver v0.158.0/go.mod h1:cOmbMK9ZbIGMhYROq9XVsk1GKAQg4EI3Or8K8wi8bjA=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -20,6 +20,7 @@ receivers:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver v0.158.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sobjectsreceiver v0.158.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/otlpjsonfilereceiver v0.158.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/webhookeventreceiver v0.158.0
   - gomod: go.opentelemetry.io/obi v0.10.0
     import: go.opentelemetry.io/obi/collector
 


### PR DESCRIPTION
## Summary

- Adds `webhookeventreceiver` to `manifest.yaml` and regenerates `_build/` sources
- The webhook event receiver is a push-based HTTP log receiver that accepts webhook payloads and converts them to OTel log records (beta upstream for logs)
- Jira: https://redhat.atlassian.net/browse/TRACING-6641

## Test plan

- [x] `make generate-sources` succeeds and `_build/components.go` includes the new receiver
- [x] `go mod tidy` passes (resolved on main, was broken on rhosdt-3.10)