### PR TITLE
Enable Renovate with automerge for ubi9 base images

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "packageRules": [
+    {
+      "groupName": "ubi9",
+      "automerge": true,
+      "matchPackageNames": [
+        "registry.access.redhat.com/ubi9/ubi",
+        "registry.access.redhat.com/ubi9/ubi-minimal",
+        "registry.access.redhat.com/ubi9/ubi-micro"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Add `renovate.json` with automerge enabled for ubi9 base image updates (`ubi9/ubi`, `ubi9/ubi-minimal`, `ubi9/ubi-micro`)
- Mirrors the automerge pattern already used in [konflux-opentelemetry](https://github.com/os-observability/konflux-opentelemetry/pull/990)

## Prerequisites
- [ ] Renovate/Mintmaker GitHub App must be installed on this repo
- [ ] `allow_auto_merge` must be enabled in repo Settings > General (currently `false`)

## Test plan
- [ ] Verify Renovate picks up the config and opens PRs for ubi9 digest updates
- [ ] Confirm PRs are auto-merged after CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)